### PR TITLE
4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "sql_query_analyzer"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sql_query_analyzer"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
-description = "Static analysis tool for SQL queries with 18 built-in rules for performance, security, and style"
+description = "Static analysis tool for SQL queries with 19 built-in rules for performance, security, and style"
 license = "MIT"
 repository = "https://github.com/RAprogramm/sql-query-analyzer"
 homepage = "https://github.com/RAprogramm/sql-query-analyzer"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A comprehensive SQL analysis tool that combines fast, deterministic static analy
 
 ## Highlights
 
-- **18 Built-in Rules** — Performance, style, and security checks run instantly without API calls
+- **19 Built-in Rules** — Performance, style, and security checks run instantly without API calls
 - **Schema-Aware Analysis** — Validates queries against your database schema, suggests missing indexes
 - **Multiple Output Formats** — Text, JSON, YAML, and SARIF for CI/CD integration
 - **Parallel Execution** — Rules execute concurrently using [rayon](https://github.com/rayon-rs/rayon)
@@ -106,6 +106,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql --provider openai
 |----|------|----------|-------------|
 | `SEC001` | Missing WHERE in UPDATE | Error | Potentially dangerous bulk update |
 | `SEC002` | Missing WHERE in DELETE | Error | Potentially dangerous bulk delete |
+| `SEC003` | TRUNCATE detected | Error | Instant data deletion without logging |
 
 ### Schema-Aware Rules
 
@@ -311,7 +312,7 @@ For fast CI checks without external API calls:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-This runs all 18 built-in rules instantly without requiring any API keys.
+This runs all 19 built-in rules instantly without requiring any API keys.
 
 #### Advanced Usage
 
@@ -431,7 +432,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql
                       ▼
          ┌────────────────────────┐
          │    Static Analysis     │
-         │  (18 rules, parallel)  │
+         │  (19 rules, parallel)  │
          └────────────┬───────────┘
                       │
                       ▼

--- a/src/query.rs
+++ b/src/query.rs
@@ -84,6 +84,15 @@ fn parse_statement(stmt: sqlparser::ast::Statement) -> AppResult<Query> {
             }
             Ok(q)
         }
+        Statement::Truncate {
+            table_names, ..
+        } => {
+            let mut q = Query::new(raw, QueryType::Truncate);
+            for table in table_names {
+                q.tables.push(table.name.to_string().into());
+            }
+            Ok(q)
+        }
         _ => Ok(Query::new(raw, QueryType::Other))
     }
 }

--- a/src/query/types.rs
+++ b/src/query/types.rs
@@ -59,11 +59,13 @@ pub struct QueryComplexity {
 
 /// Type of SQL query
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[non_exhaustive]
 pub enum QueryType {
     Select,
     Insert,
     Update,
     Delete,
+    Truncate,
     Other
 }
 
@@ -107,6 +109,7 @@ impl std::fmt::Display for QueryType {
             Self::Insert => write!(f, "INSERT"),
             Self::Update => write!(f, "UPDATE"),
             Self::Delete => write!(f, "DELETE"),
+            Self::Truncate => write!(f, "TRUNCATE"),
             Self::Other => write!(f, "OTHER")
         }
     }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -25,7 +25,7 @@
 //!
 //! - **Performance** (`PERF001`-`PERF011`) - Query optimization issues
 //! - **Style** (`STYLE001`-`STYLE002`) - Best practice violations
-//! - **Security** (`SEC001`-`SEC002`) - Dangerous operations
+//! - **Security** (`SEC001`-`SEC003`) - Dangerous operations
 //! - **Schema** (`SCHEMA001`-`SCHEMA003`) - Schema validation (requires schema)
 //!
 //! # Configuration
@@ -185,7 +185,7 @@ impl RuleRunner {
     ///
     /// - Performance rules (PERF001-PERF011) detect query optimization issues
     /// - Style rules (STYLE001-STYLE002) enforce best practices
-    /// - Security rules (SEC001-SEC002) detect dangerous operations
+    /// - Security rules (SEC001-SEC003) detect dangerous operations
     pub fn with_config(config: RulesConfig) -> Self {
         let all_rules: Vec<Box<dyn Rule>> = vec![
             Box::new(performance::SelectStarWithoutLimit),
@@ -203,6 +203,7 @@ impl RuleRunner {
             Box::new(style::MissingTableAlias),
             Box::new(security::MissingWhereInUpdate),
             Box::new(security::MissingWhereInDelete),
+            Box::new(security::TruncateDetected),
         ];
         let rules: Vec<Box<dyn Rule>> = all_rules
             .into_iter()

--- a/tests/rules_tests.rs
+++ b/tests/rules_tests.rs
@@ -383,3 +383,21 @@ fn test_multiple_queries() {
     assert!(violations.contains(&"PERF001".to_string()));
     assert!(violations.contains(&"SEC002".to_string()));
 }
+
+#[test]
+fn test_truncate_detected() {
+    let violations = analyze_query("TRUNCATE TABLE users");
+    assert!(violations.contains(&"SEC003".to_string()));
+}
+
+#[test]
+fn test_truncate_without_table_keyword() {
+    let violations = analyze_query("TRUNCATE users");
+    assert!(violations.contains(&"SEC003".to_string()));
+}
+
+#[test]
+fn test_truncate_multiple_tables() {
+    let violations = analyze_query("TRUNCATE TABLE users, orders");
+    assert!(violations.contains(&"SEC003".to_string()));
+}


### PR DESCRIPTION
## Summary

- Add `SEC003` rule to detect `TRUNCATE` statements
- Add `Truncate` variant to `QueryType` enum
- Parse TRUNCATE statements in SQL parser
- Add comprehensive tests for TRUNCATE detection

## Changes

- `src/query/types.rs`: Add `Truncate` variant to `QueryType`
- `src/query.rs`: Parse `TRUNCATE` statements
- `src/rules/security.rs`: Implement `TruncateDetected` rule
- `src/rules.rs`: Register SEC003 rule, update docs
- `tests/rules_tests.rs`: Add TRUNCATE tests
- `README.md`: Update rules count and documentation
- `Cargo.toml`: Bump version to 0.2.1

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo doc --no-deps --all-features`
- [x] `reuse lint`
- [x] `cargo build --release --all-features`

Closes #4