### PR TITLE
26

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -64,7 +64,8 @@ pub fn convert_dialect(dialect: Dialect) -> SqlDialect {
         Dialect::Generic => SqlDialect::Generic,
         Dialect::Mysql => SqlDialect::MySQL,
         Dialect::Postgresql => SqlDialect::PostgreSQL,
-        Dialect::Sqlite => SqlDialect::SQLite
+        Dialect::Sqlite => SqlDialect::SQLite,
+        Dialect::Clickhouse => SqlDialect::ClickHouse
     }
 }
 
@@ -297,6 +298,14 @@ mod tests {
         assert!(matches!(
             convert_dialect(Dialect::Sqlite),
             SqlDialect::SQLite
+        ));
+    }
+
+    #[test]
+    fn test_convert_dialect_clickhouse() {
+        assert!(matches!(
+            convert_dialect(Dialect::Clickhouse),
+            SqlDialect::ClickHouse
         ));
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,7 +84,8 @@ pub enum Dialect {
     Generic,
     Mysql,
     Postgresql,
-    Sqlite
+    Sqlite,
+    Clickhouse
 }
 
 #[derive(Debug, Clone, ValueEnum)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -5,7 +5,9 @@ use extract::{ExtractionContext, extract_columns_from_expr, extract_from_set_exp
 use indexmap::IndexSet;
 use rayon::prelude::*;
 use sqlparser::{
-    dialect::{Dialect, GenericDialect, MySqlDialect, PostgreSqlDialect, SQLiteDialect},
+    dialect::{
+        ClickHouseDialect, Dialect, GenericDialect, MySqlDialect, PostgreSqlDialect, SQLiteDialect
+    },
     parser::Parser
 };
 pub use types::{Query, QueryType};
@@ -19,7 +21,8 @@ pub enum SqlDialect {
     Generic,
     MySQL,
     PostgreSQL,
-    SQLite
+    SQLite,
+    ClickHouse
 }
 
 impl SqlDialect {
@@ -28,7 +31,8 @@ impl SqlDialect {
             Self::Generic => Box::new(GenericDialect {}),
             Self::MySQL => Box::new(MySqlDialect {}),
             Self::PostgreSQL => Box::new(PostgreSqlDialect {}),
-            Self::SQLite => Box::new(SQLiteDialect {})
+            Self::SQLite => Box::new(SQLiteDialect {}),
+            Self::ClickHouse => Box::new(ClickHouseDialect {})
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `ClickHouse` variant to `SqlDialect` enum with `ClickHouseDialect` from sqlparser
- Add `Clickhouse` variant to CLI `Dialect` enum
- Wire dialect conversion in `convert_dialect()` function
- Add unit test for ClickHouse dialect conversion

Closes #26
Closes #27