### PR TITLE
29

### DIFF
--- a/tests/schema_tests.rs
+++ b/tests/schema_tests.rs
@@ -207,10 +207,19 @@ fn test_column_info_debug() {
         name:        "test".to_string(),
         data_type:   "INT".to_string(),
         is_nullable: true,
-        is_primary:  false
+        is_primary:  false,
+        codec:       None
     };
     let debug = format!("{:?}", col);
     assert!(debug.contains("test"));
+}
+
+#[test]
+fn test_column_info_codec_default_none() {
+    let sql = "CREATE TABLE users (id INT PRIMARY KEY)";
+    let schema = Schema::parse(sql).unwrap();
+    let users = &schema.tables["users"];
+    assert!(users.columns[0].codec.is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add `codec` field to `ColumnInfo` for ClickHouse compression codec
- Update `to_summary()` to display codec when present
- Add test for default None value

Closes #29