### PR TITLE
30

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -197,7 +197,7 @@ pub async fn run_analyze(params: AnalyzeParams, config: Config) -> AppResult<Ana
     let queries_sql = read_queries_input(&params.queries_path)?;
 
     let sql_dialect = convert_dialect(params.dialect);
-    let parsed_schema = Schema::parse(&schema_sql)?;
+    let parsed_schema = Schema::parse(&schema_sql, sql_dialect)?;
     let parsed_queries = parse_queries_cached(&queries_sql, sql_dialect)?;
     let schema_summary = parsed_schema.to_summary();
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -27,7 +27,8 @@ pub enum SqlDialect {
 }
 
 impl SqlDialect {
-    fn into_parser_dialect(self) -> Box<dyn Dialect> {
+    /// Convert to sqlparser dialect for parsing
+    pub fn into_parser_dialect(self) -> Box<dyn Dialect> {
         match self {
             Self::Generic => Box::new(GenericDialect {}),
             Self::MySQL => Box::new(MySqlDialect {}),

--- a/tests/rules_tests.rs
+++ b/tests/rules_tests.rs
@@ -21,7 +21,7 @@ fn analyze_query(sql: &str) -> Vec<String> {
 
 fn analyze_with_schema(sql: &str, schema_sql: &str) -> Vec<String> {
     let queries = parse_queries(sql, SqlDialect::Generic).unwrap();
-    let schema = Schema::parse(schema_sql).unwrap();
+    let schema = Schema::parse(schema_sql, SqlDialect::Generic).unwrap();
     let runner = RuleRunner::with_schema_and_config(schema, RulesConfig::default());
     let report = runner.analyze(&queries);
     report


### PR DESCRIPTION
## Summary

- Add `dialect: SqlDialect` parameter to `Schema::parse()` method
- Make `into_parser_dialect()` public for reuse in schema module
- Update all callers in `app.rs` and test files

Resolves #30