### PR TITLE
#80 fix: resolve cargo-quality findings

### DIFF
--- a/.github/workflows/_qual.yml
+++ b/.github/workflows/_qual.yml
@@ -17,7 +17,7 @@ jobs:
     if: inputs.rust_changed == 'true'
     steps:
       - uses: actions/checkout@v7
-      - uses: RAprogramm/cargo-quality@v0
+      - uses: RAprogramm/cargo-quality@v0.3.0
         with:
           path: .
           fail_on_issues: 'true'

--- a/src/app.rs
+++ b/src/app.rs
@@ -193,10 +193,8 @@ pub async fn execute_command(command: Commands, config: Config) -> AppResult<Com
                 dry_run,
                 no_color
             };
-
             let result = run_analyze(params, config).await?;
             let mut stdout = vec![result.static_output];
-
             if let Some(dry_run_info) = result.dry_run_info {
                 stdout.push("=== DRY RUN - Would send to LLM ===\n".to_string());
                 stdout.push(format!(
@@ -212,11 +210,9 @@ pub async fn execute_command(command: Commands, config: Config) -> AppResult<Com
                     "Note: Set LLM_API_KEY for additional AI-powered analysis\n".to_string()
                 );
             }
-
             if let Some(llm_output) = result.llm_output {
                 stdout.push(llm_output);
             }
-
             Ok(CommandOutput {
                 exit_code: result.exit_code,
                 stdout
@@ -238,10 +234,8 @@ mod tests {
     async fn test_execute_command_success() {
         let mut schema_file = NamedTempFile::new().unwrap();
         writeln!(schema_file, "CREATE TABLE users (id INT PRIMARY KEY);").unwrap();
-
         let mut queries_file = NamedTempFile::new().unwrap();
         writeln!(queries_file, "SELECT id FROM users;").unwrap();
-
         let command = Commands::Analyze {
             schema:        schema_file.path().to_path_buf(),
             queries:       queries_file.path().to_path_buf(),
@@ -255,7 +249,6 @@ mod tests {
             dry_run:       false,
             no_color:      true
         };
-
         let config = Config::default();
         let result = execute_command(command, config).await.unwrap();
         assert_eq!(result.exit_code, 0);
@@ -266,10 +259,8 @@ mod tests {
     async fn test_execute_command_dry_run() {
         let mut schema_file = NamedTempFile::new().unwrap();
         writeln!(schema_file, "CREATE TABLE test (id INT);").unwrap();
-
         let mut queries_file = NamedTempFile::new().unwrap();
         writeln!(queries_file, "SELECT id FROM test;").unwrap();
-
         let command = Commands::Analyze {
             schema:        schema_file.path().to_path_buf(),
             queries:       queries_file.path().to_path_buf(),
@@ -283,7 +274,6 @@ mod tests {
             dry_run:       true,
             no_color:      true
         };
-
         let config = Config::default();
         let result = execute_command(command, config).await.unwrap();
         let output = result.stdout.join("\n");
@@ -307,7 +297,6 @@ mod tests {
             dry_run:       false,
             no_color:      true
         };
-
         let config = Config::default();
         let result = execute_command(command, config).await;
         assert!(result.is_err());
@@ -317,10 +306,8 @@ mod tests {
     async fn test_execute_command_with_violations() {
         let mut schema_file = NamedTempFile::new().unwrap();
         writeln!(schema_file, "CREATE TABLE orders (id INT);").unwrap();
-
         let mut queries_file = NamedTempFile::new().unwrap();
         writeln!(queries_file, "SELECT * FROM orders;").unwrap();
-
         let command = Commands::Analyze {
             schema:        schema_file.path().to_path_buf(),
             queries:       queries_file.path().to_path_buf(),
@@ -334,7 +321,6 @@ mod tests {
             dry_run:       false,
             no_color:      true
         };
-
         let config = Config::default();
         let result = execute_command(command, config).await.unwrap();
         assert!(result.exit_code >= 0);
@@ -344,10 +330,8 @@ mod tests {
     async fn test_execute_command_json_format() {
         let mut schema_file = NamedTempFile::new().unwrap();
         writeln!(schema_file, "CREATE TABLE items (id INT PRIMARY KEY);").unwrap();
-
         let mut queries_file = NamedTempFile::new().unwrap();
         writeln!(queries_file, "SELECT id FROM items;").unwrap();
-
         let command = Commands::Analyze {
             schema:        schema_file.path().to_path_buf(),
             queries:       queries_file.path().to_path_buf(),
@@ -361,7 +345,6 @@ mod tests {
             dry_run:       false,
             no_color:      true
         };
-
         let config = Config::default();
         let result = execute_command(command, config).await.unwrap();
         let output = result.stdout.join("");
@@ -372,10 +355,8 @@ mod tests {
     async fn test_execute_command_verbose() {
         let mut schema_file = NamedTempFile::new().unwrap();
         writeln!(schema_file, "CREATE TABLE logs (id INT);").unwrap();
-
         let mut queries_file = NamedTempFile::new().unwrap();
         writeln!(queries_file, "SELECT id FROM logs;").unwrap();
-
         let command = Commands::Analyze {
             schema:        schema_file.path().to_path_buf(),
             queries:       queries_file.path().to_path_buf(),
@@ -389,7 +370,6 @@ mod tests {
             dry_run:       false,
             no_color:      true
         };
-
         let config = Config::default();
         let result = execute_command(command, config).await.unwrap();
         assert!(!result.stdout.is_empty());
@@ -399,10 +379,8 @@ mod tests {
     async fn test_execute_command_yaml_format() {
         let mut schema_file = NamedTempFile::new().unwrap();
         writeln!(schema_file, "CREATE TABLE events (id INT);").unwrap();
-
         let mut queries_file = NamedTempFile::new().unwrap();
         writeln!(queries_file, "SELECT id FROM events;").unwrap();
-
         let command = Commands::Analyze {
             schema:        schema_file.path().to_path_buf(),
             queries:       queries_file.path().to_path_buf(),
@@ -416,7 +394,6 @@ mod tests {
             dry_run:       false,
             no_color:      true
         };
-
         let config = Config::default();
         let result = execute_command(command, config).await.unwrap();
         assert!(!result.stdout.is_empty());
@@ -426,10 +403,8 @@ mod tests {
     async fn test_execute_command_sarif_format() {
         let mut schema_file = NamedTempFile::new().unwrap();
         writeln!(schema_file, "CREATE TABLE metrics (id INT);").unwrap();
-
         let mut queries_file = NamedTempFile::new().unwrap();
         writeln!(queries_file, "SELECT id FROM metrics;").unwrap();
-
         let command = Commands::Analyze {
             schema:        schema_file.path().to_path_buf(),
             queries:       queries_file.path().to_path_buf(),
@@ -443,7 +418,6 @@ mod tests {
             dry_run:       false,
             no_color:      true
         };
-
         let config = Config::default();
         let result = execute_command(command, config).await.unwrap();
         let output = result.stdout.join("");
@@ -454,7 +428,6 @@ mod tests {
     async fn test_execute_command_stdin_path() {
         let mut schema_file = NamedTempFile::new().unwrap();
         writeln!(schema_file, "CREATE TABLE stdin_test (id INT);").unwrap();
-
         let command = Commands::Analyze {
             schema:        schema_file.path().to_path_buf(),
             queries:       PathBuf::from("-"),
@@ -468,7 +441,6 @@ mod tests {
             dry_run:       true,
             no_color:      true
         };
-
         let config = Config::default();
         let result = execute_command(command, config).await;
         assert!(result.is_err() || result.is_ok());
@@ -478,10 +450,8 @@ mod tests {
     async fn test_execute_command_mysql_dialect() {
         let mut schema_file = NamedTempFile::new().unwrap();
         writeln!(schema_file, "CREATE TABLE t (id INT PRIMARY KEY);").unwrap();
-
         let mut queries_file = NamedTempFile::new().unwrap();
         writeln!(queries_file, "SELECT id FROM t;").unwrap();
-
         let command = Commands::Analyze {
             schema:        schema_file.path().to_path_buf(),
             queries:       queries_file.path().to_path_buf(),
@@ -495,7 +465,6 @@ mod tests {
             dry_run:       false,
             no_color:      true
         };
-
         let config = Config::default();
         let result = execute_command(command, config).await.unwrap();
         assert_eq!(result.exit_code, 0);
@@ -505,10 +474,8 @@ mod tests {
     async fn test_execute_command_postgresql_dialect() {
         let mut schema_file = NamedTempFile::new().unwrap();
         writeln!(schema_file, "CREATE TABLE t (id INT PRIMARY KEY);").unwrap();
-
         let mut queries_file = NamedTempFile::new().unwrap();
         writeln!(queries_file, "SELECT id FROM t;").unwrap();
-
         let command = Commands::Analyze {
             schema:        schema_file.path().to_path_buf(),
             queries:       queries_file.path().to_path_buf(),
@@ -522,7 +489,6 @@ mod tests {
             dry_run:       false,
             no_color:      true
         };
-
         let config = Config::default();
         let result = execute_command(command, config).await.unwrap();
         assert_eq!(result.exit_code, 0);
@@ -532,10 +498,8 @@ mod tests {
     async fn test_execute_command_sqlite_dialect() {
         let mut schema_file = NamedTempFile::new().unwrap();
         writeln!(schema_file, "CREATE TABLE t (id INTEGER PRIMARY KEY);").unwrap();
-
         let mut queries_file = NamedTempFile::new().unwrap();
         writeln!(queries_file, "SELECT id FROM t;").unwrap();
-
         let command = Commands::Analyze {
             schema:        schema_file.path().to_path_buf(),
             queries:       queries_file.path().to_path_buf(),
@@ -549,7 +513,6 @@ mod tests {
             dry_run:       false,
             no_color:      true
         };
-
         let config = Config::default();
         let result = execute_command(command, config).await.unwrap();
         assert_eq!(result.exit_code, 0);

--- a/src/app/analyze.rs
+++ b/src/app/analyze.rs
@@ -97,7 +97,6 @@ pub async fn run_analyze(params: AnalyzeParams, config: Config) -> AppResult<Ana
     let static_report = runner.analyze(&parsed_queries);
     let static_output = format_static_analysis(&static_report, &output_opts);
     let exit_code = calculate_exit_code(&static_report);
-
     if params.dry_run {
         let queries_summary = format_queries_summary(&parsed_queries, &output_opts);
         return Ok(AnalyzeResult {
@@ -110,11 +109,9 @@ pub async fn run_analyze(params: AnalyzeParams, config: Config) -> AppResult<Ana
             })
         });
     }
-
     let effective_api_key = params.api_key.or(config.llm.api_key.clone());
     let effective_ollama_url =
         get_effective_ollama_url(params.ollama_url, config.llm.ollama_url.clone());
-
     if !has_llm_access(&effective_api_key, &params.provider) {
         return Ok(AnalyzeResult {
             exit_code,
@@ -123,7 +120,6 @@ pub async fn run_analyze(params: AnalyzeParams, config: Config) -> AppResult<Ana
             dry_run_info: None
         });
     }
-
     let model_name = get_effective_model(params.model, config.llm.model.clone(), &params.provider);
     let llm_provider = build_llm_provider(
         params.provider,
@@ -131,21 +127,17 @@ pub async fn run_analyze(params: AnalyzeParams, config: Config) -> AppResult<Ana
         model_name,
         effective_ollama_url
     )?;
-
     let pb = ProgressBar::new_spinner();
     if let Ok(style) = ProgressStyle::default_spinner().template("{spinner:.green} {msg}") {
         pb.set_style(style);
     }
     pb.set_message("Analyzing queries with LLM...");
     pb.enable_steady_tick(Duration::from_millis(100));
-
     let queries_summary = format_queries_summary(&parsed_queries, &output_opts);
     let client = LlmClient::with_retry_config(llm_provider, config.retry);
     let analysis = client.analyze(&schema_summary, &queries_summary).await?;
     pb.finish_and_clear();
-
     let llm_output = format_analysis_result(&parsed_queries, &analysis, &output_opts);
-
     Ok(AnalyzeResult {
         exit_code,
         static_output,

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,13 +197,10 @@ mod tests {
     #[tokio::test]
     async fn test_run_success() {
         use std::io::Write;
-
         let mut schema = NamedTempFile::new().unwrap();
         writeln!(schema, "CREATE TABLE t (id INT);").unwrap();
-
         let mut queries = NamedTempFile::new().unwrap();
         writeln!(queries, "SELECT id FROM t;").unwrap();
-
         let cmd = Commands::Analyze {
             schema:        schema.path().to_path_buf(),
             queries:       queries.path().to_path_buf(),
@@ -217,7 +214,6 @@ mod tests {
             dry_run:       false,
             no_color:      true
         };
-
         let result = run(cmd).await.unwrap();
         assert_eq!(result.exit_code, 0);
     }
@@ -237,7 +233,6 @@ mod tests {
             dry_run:       false,
             no_color:      true
         };
-
         let result = run(cmd).await;
         assert!(result.is_err());
     }
@@ -254,13 +249,10 @@ mod tests {
     #[tokio::test]
     async fn test_run_dry_run() {
         use std::io::Write;
-
         let mut schema = NamedTempFile::new().unwrap();
         writeln!(schema, "CREATE TABLE x (id INT);").unwrap();
-
         let mut queries = NamedTempFile::new().unwrap();
         writeln!(queries, "SELECT * FROM x;").unwrap();
-
         let cmd = Commands::Analyze {
             schema:        schema.path().to_path_buf(),
             queries:       queries.path().to_path_buf(),
@@ -274,7 +266,6 @@ mod tests {
             dry_run:       true,
             no_color:      true
         };
-
         let result = run(cmd).await.unwrap();
         let output = result.stdout.join("\n");
         assert!(output.contains("DRY RUN"));

--- a/src/output.rs
+++ b/src/output.rs
@@ -281,8 +281,10 @@ fn format_text_analysis(report: &AnalysisReport, opts: &OutputOptions) -> String
             }
         };
         output.push_str(&format!(
-            "  [{:>5}] {}: {}\n",
-            severity_str, violation.rule_id, violation.message
+            "  [{severity:>5}] {rule_id}: {message}\n",
+            severity = severity_str,
+            rule_id = violation.rule_id,
+            message = violation.message
         ));
         if let Some(suggestion) = &violation.suggestion {
             let suggestion_line = format!("         → {}\n", suggestion);

--- a/src/preprocessor/clickhouse.rs
+++ b/src/preprocessor/clickhouse.rs
@@ -68,19 +68,15 @@ static SETTING_PAIR_REGEX: LazyLock<Regex> =
 pub fn preprocess(sql: &str) -> PreprocessorResult {
     let mut metadata = PreprocessorMetadata::default();
     let mut result = sql.to_string();
-
     extract_codecs(&result, &mut metadata);
     extract_ttl(&result, &mut metadata);
     extract_settings(&result, &mut metadata);
     extract_partition_by(&result, &mut metadata);
-
     result = remove_codecs(&result);
     result = remove_ttl(&result);
     result = remove_settings(&result);
     result = remove_partition_by(&result);
-
     result = normalize_whitespace(&result);
-
     PreprocessorResult {
         sql: result,
         metadata
@@ -246,13 +242,11 @@ mod tests {
             SETTINGS index_granularity = 8192
         "#;
         let result = preprocess(sql);
-
         assert!(!result.sql.contains("CODEC"));
         assert!(!result.sql.contains("TTL"));
         assert!(!result.sql.contains("SETTINGS"));
         assert!(result.sql.contains("ENGINE = ReplicatedMergeTree"));
         assert!(result.sql.contains("ORDER BY"));
-
         assert_eq!(result.metadata.codecs.len(), 3);
         assert_eq!(result.metadata.ttl_expressions.len(), 1);
         assert_eq!(

--- a/tests/binary_tests.rs
+++ b/tests/binary_tests.rs
@@ -3,6 +3,7 @@
 use std::io::Write;
 
 use assert_cmd::{Command, cargo::cargo_bin_cmd};
+use predicate::str::contains;
 use predicates::prelude::*;
 use tempfile::NamedTempFile;
 
@@ -14,10 +15,8 @@ fn cmd() -> Command {
 fn test_analyze_success() {
     let mut schema = NamedTempFile::new().unwrap();
     writeln!(schema, "CREATE TABLE users (id INT PRIMARY KEY);").unwrap();
-
     let mut queries = NamedTempFile::new().unwrap();
     writeln!(queries, "SELECT id FROM users;").unwrap();
-
     cmd()
         .args([
             "analyze",
@@ -37,10 +36,8 @@ fn test_analyze_success() {
 fn test_analyze_with_violations() {
     let mut schema = NamedTempFile::new().unwrap();
     writeln!(schema, "CREATE TABLE orders (id INT);").unwrap();
-
     let mut queries = NamedTempFile::new().unwrap();
     writeln!(queries, "SELECT * FROM orders;").unwrap();
-
     cmd()
         .args([
             "analyze",
@@ -53,7 +50,7 @@ fn test_analyze_with_violations() {
             "--no-color"
         ])
         .assert()
-        .stdout(predicate::str::contains("STYLE001").or(predicate::str::contains("PERF")));
+        .stdout(contains("STYLE001").or(contains("PERF")));
 }
 
 #[test]
@@ -70,17 +67,15 @@ fn test_analyze_file_not_found() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("Error"));
+        .stderr(contains("Error"));
 }
 
 #[test]
 fn test_analyze_dry_run() {
     let mut schema = NamedTempFile::new().unwrap();
     writeln!(schema, "CREATE TABLE t (id INT);").unwrap();
-
     let mut queries = NamedTempFile::new().unwrap();
     writeln!(queries, "SELECT id FROM t;").unwrap();
-
     cmd()
         .args([
             "analyze",
@@ -95,17 +90,15 @@ fn test_analyze_dry_run() {
         ])
         .assert()
         .success()
-        .stdout(predicate::str::contains("DRY RUN"));
+        .stdout(contains("DRY RUN"));
 }
 
 #[test]
 fn test_analyze_json_format() {
     let mut schema = NamedTempFile::new().unwrap();
     writeln!(schema, "CREATE TABLE items (id INT);").unwrap();
-
     let mut queries = NamedTempFile::new().unwrap();
     writeln!(queries, "SELECT id FROM items;").unwrap();
-
     cmd()
         .args([
             "analyze",
@@ -121,17 +114,15 @@ fn test_analyze_json_format() {
         ])
         .assert()
         .success()
-        .stdout(predicate::str::contains("{"));
+        .stdout(contains("{"));
 }
 
 #[test]
 fn test_analyze_yaml_format() {
     let mut schema = NamedTempFile::new().unwrap();
     writeln!(schema, "CREATE TABLE events (id INT);").unwrap();
-
     let mut queries = NamedTempFile::new().unwrap();
     writeln!(queries, "SELECT id FROM events;").unwrap();
-
     cmd()
         .args([
             "analyze",
@@ -153,10 +144,8 @@ fn test_analyze_yaml_format() {
 fn test_analyze_sarif_format() {
     let mut schema = NamedTempFile::new().unwrap();
     writeln!(schema, "CREATE TABLE metrics (id INT);").unwrap();
-
     let mut queries = NamedTempFile::new().unwrap();
     writeln!(queries, "SELECT id FROM metrics;").unwrap();
-
     cmd()
         .args([
             "analyze",
@@ -172,7 +161,7 @@ fn test_analyze_sarif_format() {
         ])
         .assert()
         .success()
-        .stdout(predicate::str::contains("$schema"));
+        .stdout(contains("$schema"));
 }
 
 #[test]
@@ -189,10 +178,8 @@ fn test_version() {
 fn test_analyze_verbose() {
     let mut schema = NamedTempFile::new().unwrap();
     writeln!(schema, "CREATE TABLE logs (id INT);").unwrap();
-
     let mut queries = NamedTempFile::new().unwrap();
     writeln!(queries, "SELECT id FROM logs;").unwrap();
-
     cmd()
         .args([
             "analyze",
@@ -213,10 +200,8 @@ fn test_analyze_verbose() {
 fn test_analyze_mysql_dialect() {
     let mut schema = NamedTempFile::new().unwrap();
     writeln!(schema, "CREATE TABLE t (id INT PRIMARY KEY);").unwrap();
-
     let mut queries = NamedTempFile::new().unwrap();
     writeln!(queries, "SELECT id FROM t;").unwrap();
-
     cmd()
         .args([
             "analyze",
@@ -242,10 +227,8 @@ fn test_analyze_clickhouse_dialect() {
         "CREATE TABLE t (id UInt64) ENGINE = MergeTree ORDER BY id;"
     )
     .unwrap();
-
     let mut queries = NamedTempFile::new().unwrap();
     writeln!(queries, "SELECT id FROM t;").unwrap();
-
     cmd()
         .args([
             "analyze",


### PR DESCRIPTION
Closes #80

The qual job fails on main with 85 cargo-quality findings surfaced by PR #79 (first rust-flagged run in a while):

- empty_lines (78): removed empty lines inside function bodies in src/app/analyze.rs, src/app.rs, src/main.rs, src/preprocessor/clickhouse.rs, tests/binary_tests.rs
- path_import (6): predicates imports in tests/binary_tests.rs (cargo qual fix)
- format_args (1): named format arguments in src/output.rs

Local checks: cargo qual check (0 issues), nightly fmt --check, clippy -D warnings, full test suite — all green.