### PR TITLE
#84 ci: automate dependency updates and fix audit check publishing

### DIFF
--- a/.github/workflows/_audit.yml
+++ b/.github/workflows/_audit.yml
@@ -15,6 +15,9 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     if: inputs.deps_changed == 'true'
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v7
       - uses: rustsec/audit-check@v2

--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 RAprogramm
+# SPDX-License-Identifier: MIT
+
+name: Scheduled Cargo Update
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cargo-update:
+    name: Update Cargo.lock
+    runs-on: ubuntu-latest
+    if: github.repository == 'RAprogramm/sql-query-analyzer'
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Update lockfile
+        run: cargo update 2>&1 | tee /tmp/cargo-update.log
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: automation/cargo-update
+          title: "chore: weekly cargo update of transitive dependencies"
+          commit-message: "chore: cargo update transitive dependencies"
+          body: |
+            Weekly scheduled `cargo update` to keep transitive dependencies
+            fresh and RUSTSEC advisories resolved without waiting for
+            dependabot per-crate PRs.
+          labels: dependencies
+          delete-branch: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,3 +226,37 @@ jobs:
       new_tag: ${{ needs.should-release.outputs.release }}
     secrets:
       CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+
+  # Aggregate gate: single required status context for branch protection
+  ci-success:
+    name: CI Success
+    needs:
+      [
+        pr-size,
+        detect,
+        fmt,
+        clippy,
+        qual,
+        test,
+        doc,
+        doctest,
+        audit,
+        deny,
+        reuse,
+        msrv,
+        semver,
+        machete,
+        build
+      ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no job failed or was cancelled
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          echo "$RESULTS"
+          if echo "$RESULTS" | grep -qE 'failure|cancelled'; then
+            echo "::error::One or more required jobs failed or were cancelled"
+            exit 1
+          fi

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 RAprogramm
+# SPDX-License-Identifier: MIT
+
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && github.repository == 'RAprogramm/sql-query-analyzer'
+    steps:
+      - name: Fetch dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for Dependabot PR
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #84

- dependabot-automerge.yml: enables GitHub auto-merge (squash) on dependabot PRs; merges happen only after required checks pass
- cargo-update.yml: weekly scheduled cargo update PR for transitive deps (stale transitive deps caused the RUSTSEC audit failures blocking #69/#70/#75/#77)
- _audit.yml: grant checks: write so rustsec/audit-check can publish its check run (fixes "Resource not accessible by integration")
- ci.yml: new aggregate "CI Success" job as the single required status context; branch protection on main requiring it will be enabled right after merge

actionlint and reuse lint pass locally.