### PR TITLE
#86 ci: unpin cargo-quality action back to v0

### DIFF
--- a/.github/workflows/_qual.yml
+++ b/.github/workflows/_qual.yml
@@ -17,7 +17,7 @@ jobs:
     if: inputs.rust_changed == 'true'
     steps:
       - uses: actions/checkout@v7
-      - uses: RAprogramm/cargo-quality@v0.3.0
+      - uses: RAprogramm/cargo-quality@v0
         with:
           path: .
           fail_on_issues: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
   audit:
     needs: detect
     if: always() && needs.detect.result == 'success' && needs.detect.outputs.deps == 'true'
+    permissions:
+      contents: read
+      checks: write
     uses: ./.github/workflows/_audit.yml
     with:
       deps_changed: ${{ needs.detect.outputs.deps }}


### PR DESCRIPTION
Closes #86

cargo-quality 0.4.1 fixed the zero-findings exit-1 bug (RAprogramm/cargo-quality#100) and the v0 tag now points at the fixed release. Reverts the temporary v0.3.0 pin from #80.