### PR TITLE
#90 ci: add scorecard, zizmor, codeql and release attestations

### DIFF
--- a/.github/workflows/_audit.yml
+++ b/.github/workflows/_audit.yml
@@ -19,7 +19,9 @@ jobs:
       contents: read
       checks: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: rustsec/audit-check@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -16,11 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.rust_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build --release --all-features
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sql-query-analyzer
           path: target/release/sql-query-analyzer

--- a/.github/workflows/_changelog.yml
+++ b/.github/workflows/_changelog.yml
@@ -11,13 +11,14 @@ jobs:
     name: Update Changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Generate changelog
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: cliff.toml
           args: --verbose

--- a/.github/workflows/_clippy.yml
+++ b/.github/workflows/_clippy.yml
@@ -16,9 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.rust_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/_deny.yml
+++ b/.github/workflows/_deny.yml
@@ -16,8 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.deps_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check
           arguments: --all-features

--- a/.github/workflows/_detect.yml
+++ b/.github/workflows/_detect.yml
@@ -25,10 +25,11 @@ jobs:
       deps: ${{ steps.filter.outputs.deps }}
       reuse: ${{ steps.filter.outputs.reuse }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2
-      - uses: dorny/paths-filter@v4
+          persist-credentials: false
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           filters: |
@@ -50,6 +51,10 @@ jobs:
               - '**/*.md'
       - name: Debug outputs
         run: |
-          echo "rust=${{ steps.filter.outputs.rust }}"
-          echo "deps=${{ steps.filter.outputs.deps }}"
-          echo "reuse=${{ steps.filter.outputs.reuse }}"
+          echo "rust=${STEPS_FILTER_OUTPUTS_RUST}"
+          echo "deps=${STEPS_FILTER_OUTPUTS_DEPS}"
+          echo "reuse=${STEPS_FILTER_OUTPUTS_REUSE}"
+        env:
+          STEPS_FILTER_OUTPUTS_RUST: ${{ steps.filter.outputs.rust }}
+          STEPS_FILTER_OUTPUTS_DEPS: ${{ steps.filter.outputs.deps }}
+          STEPS_FILTER_OUTPUTS_REUSE: ${{ steps.filter.outputs.reuse }}

--- a/.github/workflows/_doc.yml
+++ b/.github/workflows/_doc.yml
@@ -16,9 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.rust_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: -D warnings

--- a/.github/workflows/_doctest.yml
+++ b/.github/workflows/_doctest.yml
@@ -16,9 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.rust_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: doctest
       - name: Run doctests

--- a/.github/workflows/_fmt.yml
+++ b/.github/workflows/_fmt.yml
@@ -16,8 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.rust_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: nightly
           components: rustfmt
       - run: cargo +nightly fmt --all -- --check

--- a/.github/workflows/_machete.yml
+++ b/.github/workflows/_machete.yml
@@ -16,11 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.deps_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: machete
-      - uses: taiki-e/install-action@cargo-machete
+      - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
+        with:
+          tool: cargo-machete
       - name: Check for unused dependencies
         run: cargo machete

--- a/.github/workflows/_msrv.yml
+++ b/.github/workflows/_msrv.yml
@@ -16,14 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.rust_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Get MSRV from Cargo.toml
         id: msrv
         run: echo "version=$(grep '^rust-version' Cargo.toml | sed 's/.*= *\"\([^\"]*\)\".*/\1/')" >> $GITHUB_OUTPUT
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: msrv-${{ steps.msrv.outputs.version }}
       - name: Check MSRV compatibility

--- a/.github/workflows/_pr-size.yml
+++ b/.github/workflows/_pr-size.yml
@@ -16,10 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && inputs.rust_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: RAprogramm/rust-prod-diff-checker@v1
+          persist-credentials: false
+      - uses: RAprogramm/rust-prod-diff-checker@887eced80cb9047d3fc202120f7d1cc484c8186b # v1.6.0
         with:
           max-lines: 200
           format: comment

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -18,9 +18,13 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Publish
         run: |
           output=$(cargo publish --token ${{ secrets.CRATES_IO_TOKEN }} --allow-dirty 2>&1) || {

--- a/.github/workflows/_qual.yml
+++ b/.github/workflows/_qual.yml
@@ -16,8 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.rust_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
-      - uses: RAprogramm/cargo-quality@v0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: RAprogramm/cargo-quality@c39e3171d7dc7897690f1e0e103b1c97761059c6 # v0.4.1
         with:
           path: .
           fail_on_issues: 'true'

--- a/.github/workflows/_release-build.yml
+++ b/.github/workflows/_release-build.yml
@@ -43,13 +43,16 @@ jobs:
             archive: zip
             cross: false
     steps:
-      - uses: actions/checkout@v7
-
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: release-${{ matrix.target }}
 
@@ -77,7 +80,7 @@ jobs:
           cd target/${{ matrix.target }}/release
           Compress-Archive -Path sql-query-analyzer.exe -DestinationPath ../../../sql-query-analyzer-${{ matrix.target }}.zip
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sql-query-analyzer-${{ matrix.target }}
           path: sql-query-analyzer-${{ matrix.target }}.${{ matrix.archive }}

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -17,6 +17,10 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -34,9 +38,49 @@ jobs:
         with:
           path: artifacts
 
+      - name: Package crate
+        run: cargo package --no-verify --allow-dirty
+
+      - name: Locate .crate file
+        id: artefact
+        run: |
+          set -euo pipefail
+          crate=$(find target/package -maxdepth 1 -name '*.crate' -print -quit)
+          if [ -z "$crate" ]; then
+            echo "::error::No .crate file produced under target/package" >&2
+            exit 1
+          fi
+          echo "path=$crate" >> "$GITHUB_OUTPUT"
+
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./
+          format: cyclonedx-json
+          output-file: sql-query-analyzer-sbom.cdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate build provenance attestation
+        id: attest
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: |
+            ${{ steps.artefact.outputs.path }}
+            sql-query-analyzer-sbom.cdx.json
+
+      - name: Stage provenance bundle
+        env:
+          BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        run: cp "$BUNDLE" sql-query-analyzer-provenance.sigstore.json
+
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ inputs.version }}
           body_path: RELEASE_NOTES.md
-          files: artifacts/**/*
+          files: |
+            artifacts/**/*
+            sql-query-analyzer-sbom.cdx.json
+            sql-query-analyzer-provenance.sigstore.json
+            ${{ steps.artefact.outputs.path }}

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -22,19 +22,20 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate release notes
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: cliff.toml
           args: --verbose --latest --strip header
         env:
           OUTPUT: RELEASE_NOTES.md
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 
@@ -53,7 +54,7 @@ jobs:
           echo "path=$crate" >> "$GITHUB_OUTPUT"
 
       - name: Generate CycloneDX SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: ./
           format: cyclonedx-json
@@ -63,7 +64,7 @@ jobs:
 
       - name: Generate build provenance attestation
         id: attest
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: |
             ${{ steps.artefact.outputs.path }}
@@ -75,7 +76,7 @@ jobs:
         run: cp "$BUNDLE" sql-query-analyzer-provenance.sigstore.json
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: v${{ inputs.version }}
           body_path: RELEASE_NOTES.md

--- a/.github/workflows/_reuse.yml
+++ b/.github/workflows/_reuse.yml
@@ -16,5 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.reuse_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
-      - uses: fsfe/reuse-action@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0

--- a/.github/workflows/_semver.yml
+++ b/.github/workflows/_semver.yml
@@ -16,13 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && inputs.rust_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: semver
-      - uses: taiki-e/install-action@cargo-semver-checks
+      - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
+        with:
+          tool: cargo-semver-checks
       - name: Check semver compatibility
         run: cargo semver-checks check-release --default-features

--- a/.github/workflows/_tag.yml
+++ b/.github/workflows/_tag.yml
@@ -21,9 +21,10 @@ jobs:
       new_tag: ${{ steps.check.outputs.new_tag }}
       version: ${{ steps.check.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for new version
         id: check
@@ -44,5 +45,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ steps.check.outputs.version }}" -m "Release v${{ steps.check.outputs.version }}"
-          git push origin "v${{ steps.check.outputs.version }}"
+          git tag -a "v${STEPS_CHECK_OUTPUTS_VERSION}" -m "Release v${STEPS_CHECK_OUTPUTS_VERSION}"
+          git push origin "v${STEPS_CHECK_OUTPUTS_VERSION}"
+        env:
+          STEPS_CHECK_OUTPUTS_VERSION: ${{ steps.check.outputs.version }}

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -19,27 +19,34 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.rust_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
+        with:
+          tool: cargo-llvm-cov
+      - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
+        with:
+          tool: nextest
       - name: Run tests with coverage
         run: cargo llvm-cov nextest --all-features --lcov --output-path lcov.info
       - name: Generate JUnit report
         run: cargo nextest run --all-features --profile ci
         continue-on-error: true
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: false
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/nextest/ci/results.junit.xml

--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -18,15 +18,19 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'RAprogramm/sql-query-analyzer'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
 
       - name: Update lockfile
         run: cargo update 2>&1 | tee /tmp/cargo-update.log
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: automation/cargo-update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -26,10 +29,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: RAprogramm/rust-prod-diff-checker@v1
+          persist-credentials: false
+      - uses: RAprogramm/rust-prod-diff-checker@887eced80cb9047d3fc202120f7d1cc484c8186b # v1.6.0
         with:
           max_prod_lines: '200'
           output_format: github
@@ -194,13 +198,16 @@ jobs:
       - name: Check if new tag
         id: check
         run: |
-          echo "new_tag='${{ needs.tag.outputs.new_tag }}'"
-          echo "version='${{ needs.tag.outputs.version }}'"
-          if [ "${{ needs.tag.outputs.new_tag }}" = "true" ]; then
+          echo "new_tag='${NEEDS_TAG_OUTPUTS_NEW_TAG}'"
+          echo "version='${NEEDS_TAG_OUTPUTS_VERSION}'"
+          if [ "${NEEDS_TAG_OUTPUTS_NEW_TAG}" = "true" ]; then
             echo "release=true" >> $GITHUB_OUTPUT
           else
             echo "release=false" >> $GITHUB_OUTPUT
           fi
+        env:
+          NEEDS_TAG_OUTPUTS_NEW_TAG: ${{ needs.tag.outputs.new_tag }}
+          NEEDS_TAG_OUTPUTS_VERSION: ${{ needs.tag.outputs.version }}
 
   # Stage 7: Release builds (only if new tag)
   release-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,8 @@ jobs:
     if: always() && needs.should-release.result == 'success' && needs.should-release.outputs.release == 'true' && needs.release-build.result == 'success'
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/_release.yml
     with:
       new_tag: ${{ needs.should-release.outputs.release }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+name: CodeQL
+
+# GitHub-native static analysis. Rust support is in public beta as of 2024;
+# the analyzer compiles the crate and runs the default + security-extended
+# query packs over the resulting database. Output lands in the Security tab.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyse
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [rust]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -13,11 +13,11 @@ jobs:
   automerge:
     name: Enable auto-merge
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && github.repository == 'RAprogramm/sql-query-analyzer'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'RAprogramm/sql-query-analyzer'
     steps:
       - name: Fetch dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install mdBook
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
           tool: mdbook
 
@@ -38,7 +38,7 @@ jobs:
         run: mdbook build docs
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: docs/book
 
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+name: Scorecard
+
+# OSSF Scorecard scans supply-chain posture (branch protection, signed
+# releases, dependency pinning, code review, etc.). Runs weekly so the
+# published score reflects the current main; running on push to main keeps
+# the public dashboard fresh between cron runs.
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 4 * * 1"
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF artefact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scorecard-results
+          path: scorecard-results.sarif
+          retention-days: 5
+
+      - name: Upload to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          sarif_file: scorecard-results.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Static security analysis of the GitHub Actions workflows themselves.
+# Complements actionlint (syntax/correctness) with zizmor's security
+# audits: credential persistence, cache poisoning, template injection,
+# ref pinning. Findings are uploaded as SARIF to code scanning.
+
+name: Zizmor
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zizmor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2026 RAprogramm
+# SPDX-License-Identifier: MIT
+
+# zizmor configuration. Each ignore below is a reviewed, deliberate
+# exception — not a suppression of an unread finding.
+
+rules:
+  # crates.io trusted publishing is not configured for this crate yet;
+  # publishing authenticates with a scoped CRATES_IO_TOKEN secret.
+  use-trusted-publishing:
+    ignore:
+      - _publish.yml
+
+  # softprops/action-gh-release creates the release from generated notes
+  # and attaches multiple asset globs in a single declarative step; the
+  # equivalent gh-cli script adds more surface than it removes.
+  superfluous-actions:
+    ignore:
+      - _release.yml


### PR DESCRIPTION
Closes #90

- scorecard.yml: OSSF Scorecard (weekly + push to main), SARIF to code scanning
- zizmor.yml: workflow security analysis on push/PR
- codeql.yml: CodeQL for Rust, security-extended + security-and-quality packs
- _release.yml: CycloneDX SBOM + SLSA build provenance attestation for the packaged crate, attached to the GitHub release; caller job in ci.yml grants id-token/attestations (integrated here because releases are created with GITHUB_TOKEN, which never triggers a separate release:published workflow)

actionlint and reuse lint pass locally.