### PR TITLE
#11 feat: add PERF013 rule detecting ORDER BY RAND()

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql --provider openai
 | `PERF009` | NOT IN with subquery | Warning | Can cause unexpected NULL behavior |
 | `PERF010` | UNION without ALL | Info | Unnecessary deduplication overhead |
 | `PERF011` | Select without where | Info | Full table scan on large tables |
+| `PERF013` | ORDER BY RAND() | Warning | Full scan and sort regardless of `LIMIT` |
 
 ### Style Rules
 

--- a/docs/src/rules/performance.md
+++ b/docs/src/rules/performance.md
@@ -112,3 +112,22 @@ impossible or acceptable.
 ## PERF011 — SELECT without WHERE or LIMIT (Info)
 
 Full table scan; intentional only for small reference tables.
+
+## PERF013 — ORDER BY RAND() (Warning)
+
+The database generates a random value for every row and sorts the whole set
+before applying `LIMIT` — O(n log n) regardless of how few rows are returned.
+Detects `RAND()`, `RANDOM()`, `NEWID()`, and `DBMS_RANDOM`.
+
+```sql
+-- Flagged
+SELECT * FROM products ORDER BY RAND() LIMIT 5;
+
+-- Better: random id range
+SELECT * FROM products
+WHERE id >= FLOOR(RAND() * (SELECT MAX(id) FROM products))
+LIMIT 5;
+
+-- Better: pre-generated indexed random column
+SELECT * FROM products ORDER BY random_sort LIMIT 5;
+```

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -23,7 +23,7 @@
 //!
 //! # Rule Categories
 //!
-//! - **Performance** (`PERF001`-`PERF011`) - Query optimization issues
+//! - **Performance** (`PERF001`-`PERF013`) - Query optimization issues
 //! - **Style** (`STYLE001`-`STYLE002`) - Best practice violations
 //! - **Security** (`SEC001`-`SEC004`) - Dangerous operations
 //! - **Schema** (`SCHEMA001`-`SCHEMA003`) - Schema validation (requires schema)
@@ -183,7 +183,7 @@ impl RuleRunner {
     ///
     /// # Notes
     ///
-    /// - Performance rules (PERF001-PERF011) detect query optimization issues
+    /// - Performance rules (PERF001-PERF013) detect query optimization issues
     /// - Style rules (STYLE001-STYLE002) enforce best practices
     /// - Security rules (SEC001-SEC004) detect dangerous operations
     pub fn with_config(config: RulesConfig) -> Self {
@@ -199,6 +199,7 @@ impl RuleRunner {
             Box::new(performance::NotInWithSubquery),
             Box::new(performance::UnionWithoutAll),
             Box::new(performance::SelectWithoutWhere),
+            Box::new(performance::OrderByRandom),
             Box::new(style::SelectStar),
             Box::new(style::MissingTableAlias),
             Box::new(security::MissingWhereInUpdate),

--- a/src/rules/performance.rs
+++ b/src/rules/performance.rs
@@ -366,6 +366,54 @@ impl Rule for MissingJoinCondition {
     }
 }
 
+/// ORDER BY RAND() forces a full scan and sort of every candidate row
+///
+/// The database must generate a random value per row and sort the whole
+/// result set before applying LIMIT, so cost stays O(n log n) regardless
+/// of how few rows are returned. Detects the MySQL, PostgreSQL, SQL Server,
+/// and Oracle spellings.
+pub struct OrderByRandom;
+
+impl Rule for OrderByRandom {
+    fn info(&self) -> RuleInfo {
+        RuleInfo {
+            id:       "PERF013",
+            name:     "ORDER BY RAND() detected",
+            severity: Severity::Warning,
+            category: RuleCategory::Performance
+        }
+    }
+
+    fn check(&self, query: &Query, query_index: usize) -> Vec<Violation> {
+        if query.query_type != QueryType::Select {
+            return vec![];
+        }
+        let upper = query.raw.to_uppercase();
+        let Some(order_pos) = upper.find("ORDER BY") else {
+            return vec![];
+        };
+        let order_part = &upper[order_pos..];
+        let random_funcs = ["RAND()", "RANDOM()", "NEWID()", "DBMS_RANDOM"];
+        if random_funcs.iter().any(|f| order_part.contains(f)) {
+            let info = self.info();
+            return vec![Violation {
+                rule_id: info.id,
+                rule_name: info.name,
+                message: "ORDER BY RAND() scans and sorts every row before applying LIMIT"
+                    .to_string(),
+                severity: info.severity,
+                category: info.category,
+                suggestion: Some(
+                    "For random selection use a random id range (WHERE id >= FLOOR(RAND() * max_id)) or a pre-generated indexed random column"
+                        .to_string()
+                ),
+                query_index
+            }];
+        }
+        vec![]
+    }
+}
+
 /// DISTINCT with ORDER BY can be inefficient
 pub struct DistinctWithOrderBy;
 

--- a/tests/rules_tests.rs
+++ b/tests/rules_tests.rs
@@ -86,6 +86,37 @@ fn test_select_star_style() {
 }
 
 #[test]
+fn test_order_by_rand_mysql() {
+    let violations = analyze_query("SELECT id FROM users ORDER BY RAND() LIMIT 5");
+    assert!(violations.contains(&"PERF013".to_string()));
+}
+
+#[test]
+fn test_order_by_random_postgres() {
+    let violations = analyze_query("SELECT id FROM users ORDER BY RANDOM() LIMIT 5");
+    assert!(violations.contains(&"PERF013".to_string()));
+}
+
+#[test]
+fn test_order_by_newid_mssql() {
+    let violations = analyze_query("SELECT id FROM users ORDER BY NEWID() LIMIT 5");
+    assert!(violations.contains(&"PERF013".to_string()));
+}
+
+#[test]
+fn test_order_by_column_ok() {
+    let violations = analyze_query("SELECT id FROM users WHERE id > 1 ORDER BY id LIMIT 5");
+    assert!(!violations.contains(&"PERF013".to_string()));
+}
+
+#[test]
+fn test_rand_in_where_not_order_by_ok() {
+    let violations =
+        analyze_query("SELECT id FROM users WHERE id >= FLOOR(RAND() * 100) ORDER BY id LIMIT 5");
+    assert!(!violations.contains(&"PERF013".to_string()));
+}
+
+#[test]
 fn test_explicit_columns_ok() {
     let violations = analyze_query("SELECT id, name FROM users LIMIT 10");
     assert!(!violations.contains(&"STYLE001".to_string()));


### PR DESCRIPTION
Closes #11

New performance rule PERF013 (Warning): flags ORDER BY RAND()/RANDOM()/NEWID()/DBMS_RANDOM, which forces a full scan and sort of every candidate row regardless of LIMIT.

- Detection scoped to the ORDER BY clause of SELECT statements (random functions in WHERE are not flagged)
- Registered in RuleRunner, README and docs rule catalog updated
- 5 new tests: MySQL/PostgreSQL/SQL Server spellings, plain column ordering, RAND() in WHERE as negative cases

Local checks: fmt, clippy -D warnings, 429 tests, cargo qual (0 issues) — all green.