### PR TITLE
#20 feat: add STYLE004 rule detecting ordinals in ORDER BY and GROUP BY

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql --provider openai
 |----|------|----------|-------------|
 | `STYLE001` | Select star | Info | Explicit column list preferred |
 | `STYLE002` | Missing table alias | Info | Multi-table queries should use aliases |
+| `STYLE004` | Ordinal in ORDER BY/GROUP BY | Info | `ORDER BY 1` breaks silently when the SELECT list changes |
 
 ### Security Rules
 

--- a/docs/src/rules/style.md
+++ b/docs/src/rules/style.md
@@ -30,3 +30,20 @@ SELECT users.id, orders.total FROM users JOIN orders ON orders.user_id = users.i
 -- Better
 SELECT u.id, o.total FROM users u JOIN orders o ON o.user_id = u.id;
 ```
+
+## STYLE004 — Ordinal in ORDER BY/GROUP BY (Info)
+
+`ORDER BY 1` sorts by SELECT-list position. Add or reorder selected columns
+and the sort silently changes — no error, just wrong results.
+
+```sql
+-- Flagged
+SELECT name, COUNT(*) FROM users GROUP BY 1;
+SELECT id, name FROM users ORDER BY 1 DESC;
+
+-- Better
+SELECT name, COUNT(*) FROM users GROUP BY name;
+SELECT id, name FROM users ORDER BY id DESC;
+```
+
+Function arguments and `LIMIT`/`OFFSET` counts are not mistaken for ordinals.

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -24,7 +24,7 @@
 //! # Rule Categories
 //!
 //! - **Performance** (`PERF001`-`PERF013`) - Query optimization issues
-//! - **Style** (`STYLE001`-`STYLE002`) - Best practice violations
+//! - **Style** (`STYLE001`-`STYLE004`) - Best practice violations
 //! - **Security** (`SEC001`-`SEC004`) - Dangerous operations
 //! - **Schema** (`SCHEMA001`-`SCHEMA003`) - Schema validation (requires schema)
 //!
@@ -184,7 +184,7 @@ impl RuleRunner {
     /// # Notes
     ///
     /// - Performance rules (PERF001-PERF013) detect query optimization issues
-    /// - Style rules (STYLE001-STYLE002) enforce best practices
+    /// - Style rules (STYLE001-STYLE004) enforce best practices
     /// - Security rules (SEC001-SEC004) detect dangerous operations
     pub fn with_config(config: RulesConfig) -> Self {
         let all_rules: Vec<Box<dyn Rule>> = vec![
@@ -202,6 +202,7 @@ impl RuleRunner {
             Box::new(performance::OrderByRandom),
             Box::new(style::SelectStar),
             Box::new(style::MissingTableAlias),
+            Box::new(style::OrdinalInOrderOrGroupBy),
             Box::new(security::MissingWhereInUpdate),
             Box::new(security::MissingWhereInDelete),
             Box::new(security::TruncateDetected),

--- a/src/rules/style.rs
+++ b/src/rules/style.rs
@@ -38,6 +38,100 @@ impl Rule for SelectStar {
     }
 }
 
+/// Ordinal column references in ORDER BY / GROUP BY
+///
+/// `ORDER BY 1, 2` sorts by SELECT-list position, so adding or reordering
+/// selected columns silently changes the sort with no error. Explicit column
+/// names keep the intent stable and readable.
+pub struct OrdinalInOrderOrGroupBy;
+
+/// Returns true when any top-level, comma-separated item of the clause
+/// segment starts with a bare integer (an ordinal reference). Commas inside
+/// parentheses are ignored so function arguments never count as items.
+fn clause_has_ordinal(segment: &str) -> bool {
+    let mut depth: i32 = 0;
+    let mut item_start = 0;
+    let mut items = Vec::new();
+    for (i, b) in segment.bytes().enumerate() {
+        match b {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            b',' if depth == 0 => {
+                items.push(&segment[item_start..i]);
+                item_start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    items.push(&segment[item_start..]);
+    items.iter().any(|item| {
+        item.split_whitespace()
+            .next()
+            .is_some_and(|tok| tok.chars().all(|c| c.is_ascii_digit()))
+    })
+}
+
+/// Extracts the clause body following `keyword`, stopping at the next
+/// clause boundary so LIMIT/OFFSET counts are never mistaken for ordinals.
+fn clause_segment<'a>(upper: &'a str, keyword: &str) -> Option<&'a str> {
+    let start = upper.find(keyword)? + keyword.len();
+    let rest = &upper[start..];
+    let terminators = [
+        " LIMIT ",
+        " OFFSET ",
+        " HAVING ",
+        " ORDER BY ",
+        " GROUP BY "
+    ];
+    let end = terminators
+        .iter()
+        .filter_map(|t| rest.find(t))
+        .min()
+        .unwrap_or(rest.len());
+    Some(&rest[..end])
+}
+
+impl Rule for OrdinalInOrderOrGroupBy {
+    fn info(&self) -> RuleInfo {
+        RuleInfo {
+            id:       "STYLE004",
+            name:     "Ordinal in ORDER BY/GROUP BY",
+            severity: Severity::Info,
+            category: RuleCategory::Style
+        }
+    }
+
+    fn check(&self, query: &Query, query_index: usize) -> Vec<Violation> {
+        if query.query_type != QueryType::Select {
+            return vec![];
+        }
+        let upper = query.raw.to_uppercase();
+        let flagged: Vec<&str> = ["ORDER BY", "GROUP BY"]
+            .into_iter()
+            .filter(|kw| clause_segment(&upper, kw).is_some_and(clause_has_ordinal))
+            .collect();
+        if flagged.is_empty() {
+            return vec![];
+        }
+        let info = self.info();
+        vec![Violation {
+            rule_id: info.id,
+            rule_name: info.name,
+            message: format!(
+                "{} uses a column ordinal instead of a column name",
+                flagged.join(" and ")
+            ),
+            severity: info.severity,
+            category: info.category,
+            suggestion: Some(
+                "Ordinals silently break when the SELECT list changes; use explicit column names"
+                    .to_string()
+            ),
+            query_index
+        }]
+    }
+}
+
 /// Tables without aliases in JOINs
 pub struct MissingTableAlias;
 

--- a/tests/rules_tests.rs
+++ b/tests/rules_tests.rs
@@ -86,6 +86,48 @@ fn test_select_star_style() {
 }
 
 #[test]
+fn test_ordinal_in_order_by() {
+    let violations = analyze_query("SELECT id, name FROM users WHERE id > 0 ORDER BY 1 LIMIT 5");
+    assert!(violations.contains(&"STYLE004".to_string()));
+}
+
+#[test]
+fn test_ordinal_in_group_by() {
+    let violations =
+        analyze_query("SELECT name, COUNT(*) FROM users WHERE id > 0 GROUP BY 1 LIMIT 5");
+    assert!(violations.contains(&"STYLE004".to_string()));
+}
+
+#[test]
+fn test_ordinal_in_order_by_list() {
+    let violations =
+        analyze_query("SELECT id, name FROM users WHERE id > 0 ORDER BY name, 2 LIMIT 5");
+    assert!(violations.contains(&"STYLE004".to_string()));
+}
+
+#[test]
+fn test_explicit_order_by_ok() {
+    let violations =
+        analyze_query("SELECT id, name FROM users WHERE id > 0 ORDER BY name DESC LIMIT 5");
+    assert!(!violations.contains(&"STYLE004".to_string()));
+}
+
+#[test]
+fn test_limit_count_not_ordinal() {
+    let violations =
+        analyze_query("SELECT id, name FROM users WHERE id > 0 ORDER BY name LIMIT 1");
+    assert!(!violations.contains(&"STYLE004".to_string()));
+}
+
+#[test]
+fn test_function_args_not_ordinal() {
+    let violations = analyze_query(
+        "SELECT id, name FROM users WHERE id > 0 ORDER BY COALESCE(name, 1) LIMIT 5"
+    );
+    assert!(!violations.contains(&"STYLE004".to_string()));
+}
+
+#[test]
 fn test_order_by_rand_mysql() {
     let violations = analyze_query("SELECT id FROM users ORDER BY RAND() LIMIT 5");
     assert!(violations.contains(&"PERF013".to_string()));


### PR DESCRIPTION
Closes #20

New style rule STYLE004 (Info): flags column ordinals in ORDER BY / GROUP BY (ORDER BY 1, GROUP BY 1) — ordinals silently change meaning when the SELECT list changes.

- Clause segments are cut at LIMIT/OFFSET/HAVING boundaries so pagination counts are never flagged
- Top-level comma splitting respects parentheses, so function arguments (COALESCE(name, 1)) are not mistaken for ordinals
- Registered in RuleRunner, README and docs updated
- 6 new tests covering ORDER BY, GROUP BY, mixed lists, and the three negative cases

Local checks: fmt, clippy -D warnings, 435 tests, cargo qual (0 issues) — all green.