### PR TITLE
#7 feat: add SEC006 rule detecting SQL injection tautologies

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql --provider openai
 | `SEC002` | Missing WHERE in DELETE | Error | Potentially dangerous bulk delete |
 | `SEC003` | TRUNCATE detected | Error | Instant data deletion without logging |
 | `SEC004` | DROP detected | Error | Permanent data/schema destruction |
+| `SEC006` | SQL injection pattern | Error | Always-true `OR` tautology (`OR 1 = 1`) |
 
 ### Schema-Aware Rules
 

--- a/docs/src/rules/security.md
+++ b/docs/src/rules/security.md
@@ -35,3 +35,24 @@ or easily audited.
 `DROP TABLE` / `DROP DATABASE` permanently destroys data and schema. The rule
 flags any DROP statement found in analyzed query files — migration tooling
 should own such statements, not application query sets.
+
+## SEC006 — SQL injection pattern
+
+An always-true `OR` tautology almost never appears in legitimate queries; it
+is the classic fingerprint of injected input widening a `WHERE` clause to
+match every row.
+
+```sql
+-- Flagged
+SELECT * FROM users WHERE name = '' OR '1' = '1';
+SELECT * FROM users WHERE id = 5 OR 1 = 1;
+
+-- Not flagged: comparing a column is not a tautology
+SELECT * FROM users WHERE id = 1 OR id = 2;
+```
+
+Comment-marker and statement-stacking heuristics are not needed at this
+layer: the analyzer works on parsed statements, where comments are already
+stripped and stacked statements are split apart. If this pattern shows up in
+extracted application queries, replace string concatenation with
+parameterized queries.

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -25,7 +25,7 @@
 //!
 //! - **Performance** (`PERF001`-`PERF013`) - Query optimization issues
 //! - **Style** (`STYLE001`-`STYLE004`) - Best practice violations
-//! - **Security** (`SEC001`-`SEC004`) - Dangerous operations
+//! - **Security** (`SEC001`-`SEC006`) - Dangerous operations
 //! - **Schema** (`SCHEMA001`-`SCHEMA003`) - Schema validation (requires schema)
 //!
 //! # Configuration
@@ -185,7 +185,7 @@ impl RuleRunner {
     ///
     /// - Performance rules (PERF001-PERF013) detect query optimization issues
     /// - Style rules (STYLE001-STYLE004) enforce best practices
-    /// - Security rules (SEC001-SEC004) detect dangerous operations
+    /// - Security rules (SEC001-SEC006) detect dangerous operations
     pub fn with_config(config: RulesConfig) -> Self {
         let all_rules: Vec<Box<dyn Rule>> = vec![
             Box::new(performance::SelectStarWithoutLimit),
@@ -207,6 +207,7 @@ impl RuleRunner {
             Box::new(security::MissingWhereInDelete),
             Box::new(security::TruncateDetected),
             Box::new(security::DropDetected),
+            Box::new(security::InjectionTautology),
         ];
         let rules: Vec<Box<dyn Rule>> = all_rules
             .into_iter()

--- a/src/rules/security.rs
+++ b/src/rules/security.rs
@@ -123,6 +123,75 @@ impl Rule for DropDetected {
     }
 }
 
+/// Detects tautology patterns associated with SQL injection
+///
+/// A comparison of two identical literals joined by OR (`OR 1 = 1`,
+/// `OR '1' = '1'`, `OR '' = ''`) is always true and almost never appears in
+/// legitimate queries; it is the classic fingerprint of injected input that
+/// widens a WHERE clause to match every row. Comment-marker and
+/// statement-stacking heuristics are handled before parsing: the analyzer
+/// receives statements re-serialized from the AST, where comments are
+/// already stripped and stacked statements are split apart.
+pub struct InjectionTautology;
+
+/// Returns true for tokens the tautology check treats as literals:
+/// single-quoted strings and bare integers.
+fn is_literal_token(tok: &str) -> bool {
+    (tok.starts_with('\'') && tok.ends_with('\'') && tok.len() >= 2)
+        || (!tok.is_empty() && tok.chars().all(|c| c.is_ascii_digit()))
+}
+
+/// Returns true when any `OR a = b` with identical literal operands
+/// appears in the uppercased query text.
+fn has_or_tautology(upper: &str) -> bool {
+    let mut search_from = 0;
+    while let Some(pos) = upper[search_from..].find(" OR ") {
+        let rest = &upper[search_from + pos + 4..];
+        let mut toks = rest.split_whitespace();
+        if let (Some(a), Some(op), Some(b)) = (toks.next(), toks.next(), toks.next())
+            && op == "="
+            && a == b
+            && is_literal_token(a)
+        {
+            return true;
+        }
+        search_from += pos + 4;
+    }
+    false
+}
+
+impl Rule for InjectionTautology {
+    fn info(&self) -> RuleInfo {
+        RuleInfo {
+            id:       "SEC006",
+            name:     "Potential SQL injection pattern",
+            severity: Severity::Error,
+            category: RuleCategory::Security
+        }
+    }
+
+    fn check(&self, query: &Query, query_index: usize) -> Vec<Violation> {
+        let upper = query.raw.to_uppercase();
+        if !has_or_tautology(&upper) {
+            return vec![];
+        }
+        let info = self.info();
+        vec![Violation {
+            rule_id: info.id,
+            rule_name: info.name,
+            message: "Query contains an always-true OR tautology, a classic SQL injection pattern"
+                .to_string(),
+            severity: info.severity,
+            category: info.category,
+            suggestion: Some(
+                "If this query is built in application code, replace string concatenation with parameterized queries"
+                    .to_string()
+            ),
+            query_index
+        }]
+    }
+}
+
 /// DELETE without WHERE affects all rows
 pub struct MissingWhereInDelete;
 

--- a/tests/rules_tests.rs
+++ b/tests/rules_tests.rs
@@ -165,6 +165,37 @@ fn test_explicit_columns_ok() {
 }
 
 #[test]
+fn test_injection_tautology_quoted() {
+    let violations = analyze_query("SELECT id FROM users WHERE name = '' OR '1' = '1' LIMIT 10");
+    assert!(violations.contains(&"SEC006".to_string()));
+}
+
+#[test]
+fn test_injection_tautology_numeric() {
+    let violations = analyze_query("SELECT id FROM users WHERE id = 5 OR 1 = 1 LIMIT 10");
+    assert!(violations.contains(&"SEC006".to_string()));
+}
+
+#[test]
+fn test_injection_tautology_empty_strings() {
+    let violations = analyze_query("SELECT id FROM users WHERE name = 'a' OR '' = '' LIMIT 10");
+    assert!(violations.contains(&"SEC006".to_string()));
+}
+
+#[test]
+fn test_or_on_columns_not_tautology() {
+    let violations = analyze_query("SELECT id FROM users WHERE id = 1 OR id = 2 LIMIT 10");
+    assert!(!violations.contains(&"SEC006".to_string()));
+}
+
+#[test]
+fn test_or_different_literals_not_tautology() {
+    let violations =
+        analyze_query("SELECT id FROM users WHERE name = 'a' OR status = 'b' LIMIT 10");
+    assert!(!violations.contains(&"SEC006".to_string()));
+}
+
+#[test]
 fn test_update_without_where() {
     let violations = analyze_query("UPDATE users SET status = 'inactive'");
     assert!(violations.contains(&"SEC001".to_string()));


### PR DESCRIPTION
Closes #7

New security rule SEC006 (Error): flags always-true OR tautologies (OR 1 = 1, OR '1' = '1', OR '' = '') — the classic fingerprint of injected input widening a WHERE clause.

- Detection compares literal operands around = after each OR; column comparisons and different literals are not flagged
- Comment-marker and statement-stacking heuristics from the issue are noted as unreachable at this layer: rules see statements re-serialized from the AST, where comments are stripped and stacked statements already split
- Registered in RuleRunner, README and docs updated
- 5 new tests: quoted/numeric/empty-string tautologies plus two negative cases

Local checks: fmt, clippy -D warnings, 440 tests, cargo qual (0 issues) — all green.