### PR TITLE
#96 ci: restore tag and changelog push credentials, unskip changelog job

### DIFF
--- a/.github/workflows/_changelog.yml
+++ b/.github/workflows/_changelog.yml
@@ -15,7 +15,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
 
       - name: Generate changelog
         uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0

--- a/.github/workflows/_tag.yml
+++ b/.github/workflows/_tag.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Check for new version
         id: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
   # Stage 5: Changelog (only on main after build)
   changelog:
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.build.result == 'success'
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.build.result == 'success'
     permissions:
       contents: write
     uses: ./.github/workflows/_changelog.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -17,3 +17,10 @@ rules:
   superfluous-actions:
     ignore:
       - _release.yml
+
+  # These two jobs push with git (the release tag and the regenerated
+  # CHANGELOG.md), so their checkouts must keep credentials.
+  artipacked:
+    ignore:
+      - _tag.yml
+      - _changelog.yml


### PR DESCRIPTION
Closes #96

Releases were silently blocked:

- _tag.yml and _changelog.yml push with git, but the blanket artipacked auto-fix from #90 set persist-credentials: false on their checkouts — v0.6.0 tag creation failed with "could not read Username". Credentials restored with reviewed zizmor ignores.
- The changelog job has been skipped on every main push in repo history: without always() in its condition, the PR-only pr-size job cascades a skip through the needs chain. Added always() (same pattern the tag job already uses).

After merge, the main push re-evaluates the tag job: v0.6.0 does not exist yet, so the tag, release build, GitHub release with SBOM/provenance, and crates.io publish all fire.

zizmor exit 0 and actionlint pass locally.