### PR TITLE
#100 ci: cancel in-progress runs only for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Closes #100

The CI concurrency group cancelled in-flight runs on every ref, so a push to main killed the previous push's release stages (tag/build/publish). cancel-in-progress is now conditional: PR runs still cancel superseded runs, main pushes queue behind the running one.