### PR TITLE
#8 feat: add SEC007 rule detecting dynamic SQL execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "sql_query_analyzer"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sql_query_analyzer"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
-description = "Static analysis tool for SQL queries with 26 built-in rules for performance, security, and style"
+description = "Static analysis tool for SQL queries with 27 built-in rules for performance, security, and style"
 license = "MIT"
 repository = "https://github.com/RAprogramm/sql-query-analyzer"
 homepage = "https://github.com/RAprogramm/sql-query-analyzer"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A comprehensive SQL analysis tool that combines fast, deterministic static analy
 
 ## Highlights
 
-- **26 Built-in Rules** — Performance, style, and security checks run instantly without API calls
+- **27 Built-in Rules** — Performance, style, and security checks run instantly without API calls
 - **Schema-Aware Analysis** — Validates queries against your database schema, suggests missing indexes
 - **Multi-Dialect Support** — Generic, MySQL, PostgreSQL, SQLite, and ClickHouse with preprocessor for dialect-specific syntax
 - **Multiple Output Formats** — Text, JSON, YAML, and SARIF for CI/CD integration
@@ -119,6 +119,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql --provider openai
 | `SEC004` | DROP detected | Error | Permanent data/schema destruction |
 | `SEC005` | GRANT/REVOKE detected | Warning | Privilege changes belong in reviewed migrations; broad grants escalate to Error |
 | `SEC006` | SQL injection pattern | Error | Always-true `OR` tautology (`OR 1 = 1`) |
+| `SEC007` | Dynamic SQL execution | Warning | `EXEC`/`EXECUTE`/`PREPARE` runs a string assembled at runtime |
 | `SEC008` | Hardcoded credential | Error | Plaintext secret in `IDENTIFIED BY`, `SET PASSWORD`, or a sensitive column |
 
 ### Schema-Aware Rules
@@ -325,7 +326,7 @@ For fast CI checks without external API calls:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-This runs all 26 built-in rules instantly without requiring any API keys.
+This runs all 27 built-in rules instantly without requiring any API keys.
 
 #### Advanced Usage
 
@@ -445,7 +446,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql
                       ▼
          ┌────────────────────────┐
          │    Static Analysis     │
-         │  (26 rules, parallel)  │
+         │  (27 rules, parallel)  │
          └────────────┬───────────┘
                       │
                       ▼

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -16,7 +16,7 @@ reach production.
 
 ## Highlights
 
-- **26 built-in rules** across performance, style, security, and schema-aware
+- **27 built-in rules** across performance, style, security, and schema-aware
   categories
 - **Schema-aware analysis** — detects missing indexes and unknown columns by
   parsing your `CREATE TABLE` statements

--- a/docs/src/rules/index.md
+++ b/docs/src/rules/index.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Rules Overview
 
-26 built-in rules across four categories. Every rule has a stable ID, a default
+27 built-in rules across four categories. Every rule has a stable ID, a default
 severity, and a suggestion attached to each violation. Rules can be disabled or
 re-weighted via [configuration](../configuration.md).
 

--- a/docs/src/rules/security.md
+++ b/docs/src/rules/security.md
@@ -75,6 +75,22 @@ stripped and stacked statements are split apart. If this pattern shows up in
 extracted application queries, replace string concatenation with
 parameterized queries.
 
+## SEC007 — Dynamic SQL execution
+
+`EXEC`/`EXECUTE`/`PREPARE` run SQL assembled at runtime; if any part of that
+string comes from user input, the construct is an injection vector the outer
+statement hides from static analysis.
+
+```sql
+-- Flagged
+EXEC('SELECT * FROM users');
+EXECUTE IMMEDIATE 'SELECT * FROM ' || table_name;
+PREPARE stmt FROM @sql;
+
+-- Safer: parameterized execution
+EXEC sp_executesql @sql, N'@id INT', @id = @user_id;
+```
+
 ## SEC008 — Hardcoded credential
 
 Secrets embedded in SQL leak through source control, slow query logs, and

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -211,6 +211,7 @@ impl RuleRunner {
             Box::new(security::InjectionTautology),
             Box::new(security::HardcodedCredential),
             Box::new(security::PrivilegeChange),
+            Box::new(security::DynamicSqlExecution),
         ];
         let rules: Vec<Box<dyn Rule>> = all_rules
             .into_iter()

--- a/src/rules/security.rs
+++ b/src/rules/security.rs
@@ -123,6 +123,52 @@ impl Rule for DropDetected {
     }
 }
 
+/// Detects dynamic SQL execution statements
+///
+/// EXEC/EXECUTE/PREPARE run SQL assembled at runtime; when any part of that
+/// string comes from user input, the construct is an injection vector that
+/// static analysis of the outer statement cannot see through. Flags the
+/// SQL Server, Oracle/PostgreSQL, and MySQL spellings.
+pub struct DynamicSqlExecution;
+
+/// Statement openers that hand a runtime string to the SQL engine.
+const DYNAMIC_SQL_OPENERS: [&str; 4] = ["EXEC(", "EXEC ", "EXECUTE", "PREPARE "];
+
+impl Rule for DynamicSqlExecution {
+    fn info(&self) -> RuleInfo {
+        RuleInfo {
+            id:       "SEC007",
+            name:     "Dynamic SQL execution",
+            severity: Severity::Warning,
+            category: RuleCategory::Security
+        }
+    }
+
+    fn check(&self, query: &Query, query_index: usize) -> Vec<Violation> {
+        let upper = query.raw.to_uppercase();
+        let trimmed = upper.trim_start();
+        if !DYNAMIC_SQL_OPENERS
+            .iter()
+            .any(|opener| trimmed.starts_with(opener))
+        {
+            return vec![];
+        }
+        let info = self.info();
+        vec![Violation {
+            rule_id: info.id,
+            rule_name: info.name,
+            message: "Dynamic SQL execution runs a string assembled at runtime".to_string(),
+            severity: info.severity,
+            category: info.category,
+            suggestion: Some(
+                "Validate every input that reaches the executed string and prefer parameterized execution (sp_executesql, prepared statements with bound parameters)"
+                    .to_string()
+            ),
+            query_index
+        }]
+    }
+}
+
 /// Detects GRANT/REVOKE privilege changes in query files
 ///
 /// Privilege changes belong in reviewed migrations, not application query

--- a/tests/rules_tests.rs
+++ b/tests/rules_tests.rs
@@ -220,6 +220,18 @@ fn test_or_different_literals_not_tautology() {
 }
 
 #[test]
+fn test_exec_string_flagged() {
+    let violations = analyze_query("EXECUTE my_procedure");
+    assert!(violations.contains(&"SEC007".to_string()));
+}
+
+#[test]
+fn test_select_not_dynamic_sql() {
+    let violations = analyze_query("SELECT id FROM users WHERE id = 1 LIMIT 5");
+    assert!(!violations.contains(&"SEC007".to_string()));
+}
+
+#[test]
 fn test_grant_statement_flagged() {
     let violations = analyze_query("GRANT SELECT ON users TO analyst");
     assert!(violations.contains(&"SEC005".to_string()));


### PR DESCRIPTION
Closes #8

New security rule SEC007 (Warning): flags EXEC/EXECUTE/PREPARE statements — SQL assembled at runtime is an injection vector static analysis of the outer statement cannot see through.

- Registered in RuleRunner; README, Cargo.toml description, docs updated to 27 rules
- Version bumped to 0.8.0 (v0.7.0 release train is already tagged/in flight)
- 2 new tests: EXECUTE positive and SELECT negative

Local checks: fmt, clippy -D warnings, 455 tests, cargo qual (0 issues), mdbook build — all green.