### PR TITLE
#17 feat: add PERF019 rule detecting large IN clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add SEC007 rule detecting dynamic SQL execution ([#102](https://github.com/RAprogramm/sql-query-analyzer/issues/102)) ([f3957e8](https://github.com/RAprogramm/sql-query-analyzer/commit/f3957e8b287e3b502ff64d07d93fbbe5e85e57d5))
+
+### Documentation
+
+- Update changelog [skip ci] ([67f0845](https://github.com/RAprogramm/sql-query-analyzer/commit/67f0845984a4297c889ffb78fbdd4a42bbb58e70))
+
+## [0.7.0] - 2026-07-14
+
+### Added
+
+- Add SEC005 rule detecting GRANT/REVOKE privilege changes ([#99](https://github.com/RAprogramm/sql-query-analyzer/issues/99)) ([efbddd8](https://github.com/RAprogramm/sql-query-analyzer/commit/efbddd87e90fd0e59a66c7b6980256b5a0d1f746))
+
+### CI/CD
+
+- Cancel in-progress runs only for pull requests ([#101](https://github.com/RAprogramm/sql-query-analyzer/issues/101)) ([a318ba4](https://github.com/RAprogramm/sql-query-analyzer/commit/a318ba47939661b536c0550651a12eb3e33279ef))
+
 ### Documentation
 
 - Update changelog [skip ci] ([e233647](https://github.com/RAprogramm/sql-query-analyzer/commit/e2336476716b9fdcde8ea79170faa62c7b599889))
 
 ## [0.6.0] - 2026-07-14
 
+### Added
+
+- Add PERF012 rule detecting COUNT(*) without WHERE ([#98](https://github.com/RAprogramm/sql-query-analyzer/issues/98)) ([07d0bfd](https://github.com/RAprogramm/sql-query-analyzer/commit/07d0bfd71377fde567c5e4b1f1906dc56f1b3041))
+- Add SEC008 rule detecting hardcoded credentials ([#95](https://github.com/RAprogramm/sql-query-analyzer/issues/95)) ([f9d96f4](https://github.com/RAprogramm/sql-query-analyzer/commit/f9d96f4c09421cb66e68b24ad11ced60bc83c830))
+- Add SEC006 rule detecting SQL injection tautologies ([#94](https://github.com/RAprogramm/sql-query-analyzer/issues/94)) ([4682b3e](https://github.com/RAprogramm/sql-query-analyzer/commit/4682b3e9b5ec4a8a11b105dddb647a614b5adced))
+- Add STYLE004 rule detecting ordinals in ORDER BY and GROUP BY ([#93](https://github.com/RAprogramm/sql-query-analyzer/issues/93)) ([1c24318](https://github.com/RAprogramm/sql-query-analyzer/commit/1c24318bd6353a061d4936bf1afb999e5797ebe0))
+- Add PERF013 rule detecting ORDER BY RAND() ([#92](https://github.com/RAprogramm/sql-query-analyzer/issues/92)) ([ea547d8](https://github.com/RAprogramm/sql-query-analyzer/commit/ea547d81a767abd2d5ee26c85f5de7d46a391d2f))
+
 ### CI/CD
 
+- Restore tag and changelog push credentials, unskip changelog job ([#97](https://github.com/RAprogramm/sql-query-analyzer/issues/97)) ([18ca01a](https://github.com/RAprogramm/sql-query-analyzer/commit/18ca01a26412dd599a3fe9f4d50c53de583d2080))
+- Add scorecard, zizmor, codeql and release attestations ([#91](https://github.com/RAprogramm/sql-query-analyzer/issues/91)) ([940f52e](https://github.com/RAprogramm/sql-query-analyzer/commit/940f52e6949fea2306d68266fb041a3c337feb01))
+- Unpin cargo-quality action back to v0 ([#87](https://github.com/RAprogramm/sql-query-analyzer/issues/87)) ([ab35eb5](https://github.com/RAprogramm/sql-query-analyzer/commit/ab35eb511a487fe3c891a13d7d4cd69793585f10))
+- Automate dependency updates and fix audit check publishing ([#85](https://github.com/RAprogramm/sql-query-analyzer/issues/85)) ([13b06a6](https://github.com/RAprogramm/sql-query-analyzer/commit/13b06a6804d95981f46341f2c5140b64fc6c6e9c))
 - Bump the github-actions group across 1 directory with 2 updates ([953c181](https://github.com/RAprogramm/sql-query-analyzer/commit/953c1810f86a85a45917d60e05b1129b6a99b296))
 - Bump the github-actions group across 1 directory with 5 updates ([2e6e200](https://github.com/RAprogramm/sql-query-analyzer/commit/2e6e200b399bc1de74f09cf84b7b6fee053bc388))
 
-### Miscellaneous
-
-- New banner ([d5a2d7c](https://github.com/RAprogramm/sql-query-analyzer/commit/d5a2d7cfd8d46456bd6de326a5325f869ac4bcc6))
-
-### Deps
+### Dependencies
 
 - Bump the rust-dependencies group across 1 directory with 2 updates ([1593445](https://github.com/RAprogramm/sql-query-analyzer/commit/15934456fb68a517d752d26e606e8c2a12a5b276))
 - Bump bytes from 1.11.0 to 1.11.1 ([49fd5be](https://github.com/RAprogramm/sql-query-analyzer/commit/49fd5be8b393e293f51b1aecadbd4394ebd45ea8))
@@ -31,10 +57,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump the rust-dependencies group with 2 updates ([9402f64](https://github.com/RAprogramm/sql-query-analyzer/commit/9402f64e56784b370c1f6232c17ce2bf364fb60e))
 - Bump the rust-dependencies group with 3 updates ([78b4db0](https://github.com/RAprogramm/sql-query-analyzer/commit/78b4db0eae0b54c2c0e9150cfbaf8c2d98a26783))
 
+### Documentation
+
+- Publish mdBook documentation site on GitHub Pages ([#89](https://github.com/RAprogramm/sql-query-analyzer/issues/89)) ([699c9a4](https://github.com/RAprogramm/sql-query-analyzer/commit/699c9a4729648e933be23a1a9d052dc1d0126ff8))
+- Add project banner to README ([#83](https://github.com/RAprogramm/sql-query-analyzer/issues/83)) ([f653dca](https://github.com/RAprogramm/sql-query-analyzer/commit/f653dca7eccc88536929ecb2a1456b7bd4e61910))
+
+### Fixed
+
+- Resolve cargo-quality findings ([#81](https://github.com/RAprogramm/sql-query-analyzer/issues/81)) ([c88306c](https://github.com/RAprogramm/sql-query-analyzer/commit/c88306c108ba064d1c6e776024f6c22206b2fdc5))
+
+### Miscellaneous
+
+- New banner ([d5a2d7c](https://github.com/RAprogramm/sql-query-analyzer/commit/d5a2d7cfd8d46456bd6de326a5325f869ac4bcc6))
+- Update dependencies to latest, bump MSRV to 1.97 ([#79](https://github.com/RAprogramm/sql-query-analyzer/issues/79)) ([4e9c4cc](https://github.com/RAprogramm/sql-query-analyzer/commit/4e9c4ccb7febc799af15a711130d329cab1fbe88))
+
 ## [0.5.2] - 2025-12-19
+
+### Added
+
+- Add SQL preprocessor for ClickHouse dialect ([86845b6](https://github.com/RAprogramm/sql-query-analyzer/commit/86845b6c8c3d616dac0863fafce2f457de9a7655))
 
 ### Changed
 
+- Split app.rs into submodules ([dfaf345](https://github.com/RAprogramm/sql-query-analyzer/commit/dfaf34530d3276110282cc924b8984d7aaa643cd))
 - Move CLI logic to app.rs for testability ([323de1e](https://github.com/RAprogramm/sql-query-analyzer/commit/323de1ef501c2c01e506645cd0448c317ec107f6))
 
 ### Documentation
@@ -52,7 +97,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extract MSRV from Cargo.toml dynamically ([7b36bfe](https://github.com/RAprogramm/sql-query-analyzer/commit/7b36bfe9d0fbab2e8d611e61d26fcc54e855b464))
 - Bump the github-actions group across 1 directory with 4 updates ([a592a67](https://github.com/RAprogramm/sql-query-analyzer/commit/a592a67a4a53f988cba98d375fdfe7b25360d0ee))
 
+### Fixed
+
+- Hide API key from help output ([4f38d06](https://github.com/RAprogramm/sql-query-analyzer/commit/4f38d06f471666752770b167c8c52065ab591a5a))
+
 ## [0.4.0] - 2025-11-30
+
+### Added
+
+- Implement ClickHouse CREATE TABLE parsing ([ba84477](https://github.com/RAprogramm/sql-query-analyzer/commit/ba844779a04e2d33747df3595e80f50a3be616bc))
+- Add dialect parameter to Schema::parse ([d45657c](https://github.com/RAprogramm/sql-query-analyzer/commit/d45657c301e8fb7d4bec59b06ea6907ec3487ef4))
+- Add codec field to ColumnInfo ([6acfd17](https://github.com/RAprogramm/sql-query-analyzer/commit/6acfd17e118f062589b0160d41124387d213ce67))
 
 ### CI/CD
 
@@ -61,13 +116,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fix cargo qual empty_lines issues ([7871034](https://github.com/RAprogramm/sql-query-analyzer/commit/78710345301ccc074ef13826438046acca58d2dc))
 - Professional PR comment UI with GitHub alerts and collapsible sections ([7772e5f](https://github.com/RAprogramm/sql-query-analyzer/commit/7772e5f2190c9b7ffb3fcfc1569f5011fa8e354a))
 
 ### Fixed
 
+- Check entire project in cargo qual CI ([a12c930](https://github.com/RAprogramm/sql-query-analyzer/commit/a12c93013efeda165872d8a5fef0627c4781ad48))
 - Assign explicit discriminants to QueryType enum for semver stability ([dc99f89](https://github.com/RAprogramm/sql-query-analyzer/commit/dc99f8949fc67579b5cd77fad834a7fc595ba6a1))
 
+### Testing
+
+- Add ClickHouse query parsing tests ([a6ce97c](https://github.com/RAprogramm/sql-query-analyzer/commit/a6ce97c38561e26a752dc186890f7e27f59d6e74))
+- Add ClickHouse CREATE TABLE parsing tests ([fc36d25](https://github.com/RAprogramm/sql-query-analyzer/commit/fc36d25f6c81e3b2ea4cc0634bfc114af78b50b0))
+
 ## [0.3.0] - 2025-11-28
+
+### Added
+
+- Add SEC003 TRUNCATE statement detection ([a96d5c1](https://github.com/RAprogramm/sql-query-analyzer/commit/a96d5c1ce89e2f9e3433117f6b214a357046051f))
 
 ### CI/CD
 
@@ -103,6 +169,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix tag workflow outputs, bump to 0.1.4 ([fbe9832](https://github.com/RAprogramm/sql-query-analyzer/commit/fbe98326f06619ac730fb58792984cf495b0ea49))
 - Trigger release ([f9dada9](https://github.com/RAprogramm/sql-query-analyzer/commit/f9dada9b4caa741769dcc309bf8f5a81ccd789e4))
 - Add description to reusable workflow outputs ([7ae1366](https://github.com/RAprogramm/sql-query-analyzer/commit/7ae13661099ef3c94911b0ddf59a712e11771166))
+- Auto-create tag and release on version bump ([6e83e62](https://github.com/RAprogramm/sql-query-analyzer/commit/6e83e62cf07b529798ff197253fc8a7e7e8c5953))
+- Add permissions for quality check PR comments ([cd6c085](https://github.com/RAprogramm/sql-query-analyzer/commit/cd6c08570927b71305d8a814d73a901dfb43f5ed))
 - Enforce PR size check before lints and qual after clippy ([ef3f26a](https://github.com/RAprogramm/sql-query-analyzer/commit/ef3f26a7ea05d1ea0a253a16c9458ef417102627))
 - Fix deny licenses and remove unused dependencies ([d639d9e](https://github.com/RAprogramm/sql-query-analyzer/commit/d639d9eced635a3c2ce17fe459e8051275544274))
 - Add comprehensive quality gates and fix doctests ([f19dc9d](https://github.com/RAprogramm/sql-query-analyzer/commit/f19dc9d2bdbbb7e76adffd5816d4d999cd5f2150))
@@ -113,6 +181,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Split CI into reusable workflows ([75bc5d2](https://github.com/RAprogramm/sql-query-analyzer/commit/75bc5d259b5a541cfc56d56b6e44dd1ad8b44d65))
 - Fix all cargo-qual issues and add quality CI job ([50c472a](https://github.com/RAprogramm/sql-query-analyzer/commit/50c472a10fad6b9475bf5e3ae59bda8041fc227a))
 
 ### Documentation
@@ -124,6 +193,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add contributing guidelines with PR size limits ([16f6e7f](https://github.com/RAprogramm/sql-query-analyzer/commit/16f6e7f3c364ccfbe75d2da18c1f304bff702030))
 - Add REUSE compliance badge ([b7f838a](https://github.com/RAprogramm/sql-query-analyzer/commit/b7f838a3d2945352495cc17429eddfa92edb9e3f))
 - Update changelog [skip ci] ([8160321](https://github.com/RAprogramm/sql-query-analyzer/commit/8160321282ba46a04e7f8b810e85621a92d6f3da))
+
+### Fixed
+
+- Use github format for pr-size limit checking ([fde1a41](https://github.com/RAprogramm/sql-query-analyzer/commit/fde1a410e77657b392f804d0ac855e3635f016e4))
+- Add pull-requests write permission for pr-size ([c697525](https://github.com/RAprogramm/sql-query-analyzer/commit/c6975258f73a42fb60edb396f617380d893c448f))
+- Use correct input names for rust-prod-diff-checker ([79188e2](https://github.com/RAprogramm/sql-query-analyzer/commit/79188e267fcc80ee4757203296671690d79c82fc))
+- Reorder CI stages and fix permissions ([dd75f2a](https://github.com/RAprogramm/sql-query-analyzer/commit/dd75f2aa66cfbdd71e83c6434b2de838e0c6bb08))
+- Move qual permissions to caller workflow ([5e8c70b](https://github.com/RAprogramm/sql-query-analyzer/commit/5e8c70b0bc2722f0f209a09d29a0fc1132e4e531))
+- Rename binary to sql-query-analyzer ([1fcfb83](https://github.com/RAprogramm/sql-query-analyzer/commit/1fcfb839e042f34524ab47dfaea159170728ac01))
 
 ### Miscellaneous
 
@@ -175,7 +253,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use rustls instead of openssl for cross-compilation ([2bdf030](https://github.com/RAprogramm/sql-query-analyzer/commit/2bdf03097c563bce1c7b70eb613f6d58bc52b0c2))
 
-[Unreleased]: https://github.com/RAprogramm/sql-query-analyzer/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/RAprogramm/sql-query-analyzer/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/RAprogramm/sql-query-analyzer/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/RAprogramm/sql-query-analyzer/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/RAprogramm/sql-query-analyzer/compare/v0.4.1...v0.5.2
 [0.4.1]: https://github.com/RAprogramm/sql-query-analyzer/compare/v0.4.0...v0.4.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "sql_query_analyzer"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sql_query_analyzer"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
-description = "Static analysis tool for SQL queries with 27 built-in rules for performance, security, and style"
+description = "Static analysis tool for SQL queries with 28 built-in rules for performance, security, and style"
 license = "MIT"
 repository = "https://github.com/RAprogramm/sql-query-analyzer"
 homepage = "https://github.com/RAprogramm/sql-query-analyzer"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A comprehensive SQL analysis tool that combines fast, deterministic static analy
 
 ## Highlights
 
-- **27 Built-in Rules** — Performance, style, and security checks run instantly without API calls
+- **28 Built-in Rules** — Performance, style, and security checks run instantly without API calls
 - **Schema-Aware Analysis** — Validates queries against your database schema, suggests missing indexes
 - **Multi-Dialect Support** — Generic, MySQL, PostgreSQL, SQLite, and ClickHouse with preprocessor for dialect-specific syntax
 - **Multiple Output Formats** — Text, JSON, YAML, and SARIF for CI/CD integration
@@ -100,6 +100,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql --provider openai
 | `PERF011` | Select without where | Info | Full table scan on large tables |
 | `PERF012` | COUNT(*) without WHERE | Warning | Counting every row scans the entire table |
 | `PERF013` | ORDER BY RAND() | Warning | Full scan and sort regardless of `LIMIT` |
+| `PERF019` | Large IN clause | Warning | 50+ values degrade planning; severity scales with size |
 
 ### Style Rules
 
@@ -326,7 +327,7 @@ For fast CI checks without external API calls:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-This runs all 27 built-in rules instantly without requiring any API keys.
+This runs all 28 built-in rules instantly without requiring any API keys.
 
 #### Advanced Usage
 
@@ -446,7 +447,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql
                       ▼
          ┌────────────────────────┐
          │    Static Analysis     │
-         │  (27 rules, parallel)  │
+         │  (28 rules, parallel)  │
          └────────────┬───────────┘
                       │
                       ▼

--- a/cliff.toml
+++ b/cliff.toml
@@ -55,6 +55,7 @@ conventional_commits = true
 filter_unconventional = true
 split_commits = false
 commit_preprocessors = [
+    { pattern = '^#[0-9]+ ', replace = "" },
     { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/RAprogramm/sql-query-analyzer/issues/${2}))" },
 ]
 commit_parsers = [
@@ -69,6 +70,7 @@ commit_parsers = [
     { message = "^ci", group = "CI/CD" },
     { message = "^chore\\(release\\)", skip = true },
     { message = "^chore\\(deps\\)", group = "Dependencies" },
+    { message = "^deps", group = "Dependencies" },
     { message = "^chore", group = "Miscellaneous" },
     { message = "^revert", group = "Reverted" },
 ]

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -16,7 +16,7 @@ reach production.
 
 ## Highlights
 
-- **27 built-in rules** across performance, style, security, and schema-aware
+- **28 built-in rules** across performance, style, security, and schema-aware
   categories
 - **Schema-aware analysis** — detects missing indexes and unknown columns by
   parsing your `CREATE TABLE` statements

--- a/docs/src/rules/index.md
+++ b/docs/src/rules/index.md
@@ -5,13 +5,13 @@ SPDX-License-Identifier: MIT
 
 # Rules Overview
 
-27 built-in rules across four categories. Every rule has a stable ID, a default
+28 built-in rules across four categories. Every rule has a stable ID, a default
 severity, and a suggestion attached to each violation. Rules can be disabled or
 re-weighted via [configuration](../configuration.md).
 
 | Category | IDs | Focus |
 |----------|-----|-------|
-| [Performance](performance.md) | `PERF001`–`PERF013` | Index usage, table scans, N+1 patterns |
+| [Performance](performance.md) | `PERF001`–`PERF019` | Index usage, table scans, N+1 patterns |
 | [Style](style.md) | `STYLE001`–`STYLE004` | Readability and maintainability |
 | [Security](security.md) | `SEC001`–`SEC008` | Destructive statements without guards |
 | [Schema-Aware](schema.md) | `SCHEMA001`–`SCHEMA003` | Cross-checking queries against DDL |

--- a/docs/src/rules/performance.md
+++ b/docs/src/rules/performance.md
@@ -147,3 +147,17 @@ LIMIT 5;
 -- Better: pre-generated indexed random column
 SELECT * FROM products ORDER BY random_sort LIMIT 5;
 ```
+
+## PERF019 — Large IN clause (Warning)
+
+Very long `IN` lists blow up parse and plan time, defeat plan caching, and on
+some engines hit hard parameter limits. Severity scales with size: more than
+50 items is Info, more than 200 Warning, more than 1000 Error. Subqueries
+(`IN (SELECT …)`) are not counted.
+
+```sql
+-- Flagged
+SELECT * FROM users WHERE id IN (1, 2, 3, /* …60 more… */ 64);
+
+-- Better: JOIN against a temporary table, or batch the lookups
+```

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -23,7 +23,7 @@
 //!
 //! # Rule Categories
 //!
-//! - **Performance** (`PERF001`-`PERF013`) - Query optimization issues
+//! - **Performance** (`PERF001`-`PERF019`) - Query optimization issues
 //! - **Style** (`STYLE001`-`STYLE004`) - Best practice violations
 //! - **Security** (`SEC001`-`SEC008`) - Dangerous operations
 //! - **Schema** (`SCHEMA001`-`SCHEMA003`) - Schema validation (requires schema)
@@ -183,7 +183,7 @@ impl RuleRunner {
     ///
     /// # Notes
     ///
-    /// - Performance rules (PERF001-PERF013) detect query optimization issues
+    /// - Performance rules (PERF001-PERF019) detect query optimization issues
     /// - Style rules (STYLE001-STYLE004) enforce best practices
     /// - Security rules (SEC001-SEC008) detect dangerous operations
     pub fn with_config(config: RulesConfig) -> Self {
@@ -201,6 +201,7 @@ impl RuleRunner {
             Box::new(performance::SelectWithoutWhere),
             Box::new(performance::OrderByRandom),
             Box::new(performance::CountWithoutWhere),
+            Box::new(performance::LargeInClause),
             Box::new(style::SelectStar),
             Box::new(style::MissingTableAlias),
             Box::new(style::OrdinalInOrderOrGroupBy),

--- a/src/rules/performance.rs
+++ b/src/rules/performance.rs
@@ -458,6 +458,90 @@ impl Rule for CountWithoutWhere {
     }
 }
 
+/// Large IN value lists degrade planning and execution
+///
+/// Very long IN lists blow up parse and plan time, defeat plan caching, and
+/// on some engines hit hard parameter limits. Severity scales with size:
+/// more than 50 items is Info, more than 200 Warning, more than 1000 Error.
+pub struct LargeInClause;
+
+/// Counts top-level comma-separated items in an IN list body, returning
+/// None when the list is a subquery rather than a value list.
+fn in_list_item_count(body: &str) -> Option<usize> {
+    if body.trim_start().starts_with("SELECT") {
+        return None;
+    }
+    let mut depth = 0usize;
+    let mut items = 1usize;
+    for b in body.bytes() {
+        match b {
+            b'(' => depth += 1,
+            b')' => {
+                if depth == 0 {
+                    break;
+                }
+                depth -= 1;
+            }
+            b',' if depth == 0 => items += 1,
+            _ => {}
+        }
+    }
+    Some(items)
+}
+
+/// Returns the largest IN value-list size found in the statement.
+fn max_in_list_size(upper: &str) -> usize {
+    let mut max_items = 0;
+    let mut search_from = 0;
+    while let Some(pos) = upper[search_from..].find(" IN (") {
+        let body_start = search_from + pos + " IN (".len();
+        if let Some(items) = in_list_item_count(&upper[body_start..]) {
+            max_items = max_items.max(items);
+        }
+        search_from = body_start;
+    }
+    max_items
+}
+
+impl Rule for LargeInClause {
+    fn info(&self) -> RuleInfo {
+        RuleInfo {
+            id:       "PERF019",
+            name:     "Large IN clause",
+            severity: Severity::Warning,
+            category: RuleCategory::Performance
+        }
+    }
+
+    fn check(&self, query: &Query, query_index: usize) -> Vec<Violation> {
+        let upper = query.raw.to_uppercase();
+        let items = max_in_list_size(&upper);
+        if items <= 50 {
+            return vec![];
+        }
+        let severity = if items > 1000 {
+            Severity::Error
+        } else if items > 200 {
+            Severity::Warning
+        } else {
+            Severity::Info
+        };
+        let info = self.info();
+        vec![Violation {
+            rule_id: info.id,
+            rule_name: info.name,
+            message: format!("IN clause contains {} values", items),
+            severity,
+            category: info.category,
+            suggestion: Some(
+                "Load the values into a temporary table and JOIN against it, or split the query into batches"
+                    .to_string()
+            ),
+            query_index
+        }]
+    }
+}
+
 /// DISTINCT with ORDER BY can be inefficient
 pub struct DistinctWithOrderBy;
 

--- a/tests/rules_tests.rs
+++ b/tests/rules_tests.rs
@@ -151,6 +151,46 @@ fn test_select_without_count_not_perf012() {
     assert!(!violations.contains(&"PERF012".to_string()));
 }
 
+fn in_list_query(n: usize) -> String {
+    let values: Vec<String> = (1..=n).map(|i| i.to_string()).collect();
+    format!(
+        "SELECT id FROM users WHERE id IN ({}) LIMIT 10",
+        values.join(", ")
+    )
+}
+
+#[test]
+fn test_large_in_clause_flagged() {
+    let violations = analyze_query(&in_list_query(60));
+    assert!(violations.contains(&"PERF019".to_string()));
+}
+
+#[test]
+fn test_small_in_clause_ok() {
+    let violations = analyze_query(&in_list_query(10));
+    assert!(!violations.contains(&"PERF019".to_string()));
+}
+
+#[test]
+fn test_huge_in_clause_is_error() {
+    let queries = parse_queries(&in_list_query(1500), SqlDialect::Generic).unwrap();
+    let report = RuleRunner::new().analyze(&queries);
+    let violation = report
+        .violations
+        .iter()
+        .find(|v| v.rule_id == "PERF019")
+        .unwrap();
+    assert_eq!(violation.severity, Severity::Error);
+}
+
+#[test]
+fn test_in_subquery_not_counted() {
+    let violations = analyze_query(
+        "SELECT id FROM users WHERE id IN (SELECT user_id FROM orders WHERE total > 0) LIMIT 10"
+    );
+    assert!(!violations.contains(&"PERF019".to_string()));
+}
+
 #[test]
 fn test_order_by_rand_mysql() {
     let violations = analyze_query("SELECT id FROM users ORDER BY RAND() LIMIT 5");


### PR DESCRIPTION
Closes #17

New performance rule PERF019: flags IN value lists above 50 items; severity scales with size (>50 Info, >200 Warning, >1000 Error). Subqueries in IN are not counted; parentheses inside items are handled.

Also in this PR (committed on direct user request): cliff.toml commit parsing fix — the leading issue-number prefix made every "#N feat:" commit unparseable, so release notes and CHANGELOG dropped all features; CHANGELOG regenerated, v0.6.0/v0.7.0 release notes already rewritten in place.

- README, Cargo.toml description, docs updated to 28 rules; version bumped to 0.9.0
- 4 new tests incl. severity escalation and IN-subquery negative

Local checks: fmt, clippy -D warnings, 459 tests, cargo qual (0 issues), mdbook build — all green.