### PR TITLE
#16 feat: add PERF018 rule detecting HAVING without aggregate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "sql_query_analyzer"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sql_query_analyzer"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
-description = "Static analysis tool for SQL queries with 28 built-in rules for performance, security, and style"
+description = "Static analysis tool for SQL queries with 29 built-in rules for performance, security, and style"
 license = "MIT"
 repository = "https://github.com/RAprogramm/sql-query-analyzer"
 homepage = "https://github.com/RAprogramm/sql-query-analyzer"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A comprehensive SQL analysis tool that combines fast, deterministic static analy
 
 ## Highlights
 
-- **28 Built-in Rules** — Performance, style, and security checks run instantly without API calls
+- **29 Built-in Rules** — Performance, style, and security checks run instantly without API calls
 - **Schema-Aware Analysis** — Validates queries against your database schema, suggests missing indexes
 - **Multi-Dialect Support** — Generic, MySQL, PostgreSQL, SQLite, and ClickHouse with preprocessor for dialect-specific syntax
 - **Multiple Output Formats** — Text, JSON, YAML, and SARIF for CI/CD integration
@@ -100,6 +100,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql --provider openai
 | `PERF011` | Select without where | Info | Full table scan on large tables |
 | `PERF012` | COUNT(*) without WHERE | Warning | Counting every row scans the entire table |
 | `PERF013` | ORDER BY RAND() | Warning | Full scan and sort regardless of `LIMIT` |
+| `PERF018` | HAVING without aggregate | Warning | Non-aggregate conditions belong in `WHERE` |
 | `PERF019` | Large IN clause | Warning | 50+ values degrade planning; severity scales with size |
 
 ### Style Rules
@@ -327,7 +328,7 @@ For fast CI checks without external API calls:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-This runs all 28 built-in rules instantly without requiring any API keys.
+This runs all 29 built-in rules instantly without requiring any API keys.
 
 #### Advanced Usage
 
@@ -447,7 +448,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql
                       ▼
          ┌────────────────────────┐
          │    Static Analysis     │
-         │  (28 rules, parallel)  │
+         │  (29 rules, parallel)  │
          └────────────┬───────────┘
                       │
                       ▼

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -16,7 +16,7 @@ reach production.
 
 ## Highlights
 
-- **28 built-in rules** across performance, style, security, and schema-aware
+- **29 built-in rules** across performance, style, security, and schema-aware
   categories
 - **Schema-aware analysis** — detects missing indexes and unknown columns by
   parsing your `CREATE TABLE` statements

--- a/docs/src/rules/index.md
+++ b/docs/src/rules/index.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Rules Overview
 
-28 built-in rules across four categories. Every rule has a stable ID, a default
+29 built-in rules across four categories. Every rule has a stable ID, a default
 severity, and a suggestion attached to each violation. Rules can be disabled or
 re-weighted via [configuration](../configuration.md).
 

--- a/docs/src/rules/performance.md
+++ b/docs/src/rules/performance.md
@@ -148,6 +148,22 @@ LIMIT 5;
 SELECT * FROM products ORDER BY random_sort LIMIT 5;
 ```
 
+## PERF018 — HAVING without aggregate (Warning)
+
+`HAVING` filters after grouping; a condition on plain columns forces the
+engine to group rows it could have discarded up front.
+
+```sql
+-- Flagged
+SELECT status, COUNT(*) FROM orders GROUP BY status HAVING status = 'active';
+
+-- Better: prune before grouping
+SELECT status, COUNT(*) FROM orders WHERE status = 'active' GROUP BY status;
+
+-- Correct HAVING usage is not flagged
+SELECT status, COUNT(*) FROM orders GROUP BY status HAVING COUNT(*) > 10;
+```
+
 ## PERF019 — Large IN clause (Warning)
 
 Very long `IN` lists blow up parse and plan time, defeat plan caching, and on

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -202,6 +202,7 @@ impl RuleRunner {
             Box::new(performance::OrderByRandom),
             Box::new(performance::CountWithoutWhere),
             Box::new(performance::LargeInClause),
+            Box::new(performance::HavingWithoutAggregate),
             Box::new(style::SelectStar),
             Box::new(style::MissingTableAlias),
             Box::new(style::OrdinalInOrderOrGroupBy),

--- a/src/rules/performance.rs
+++ b/src/rules/performance.rs
@@ -542,6 +542,70 @@ impl Rule for LargeInClause {
     }
 }
 
+/// HAVING without an aggregate belongs in WHERE
+///
+/// HAVING filters after grouping, so a condition on plain columns forces the
+/// engine to group rows it could have discarded up front. Moving the
+/// condition into WHERE prunes rows before the GROUP BY.
+pub struct HavingWithoutAggregate;
+
+/// Aggregate function openers that justify a HAVING clause.
+const AGGREGATE_OPENERS: [&str; 9] = [
+    "COUNT(",
+    "SUM(",
+    "AVG(",
+    "MIN(",
+    "MAX(",
+    "GROUP_CONCAT(",
+    "STRING_AGG(",
+    "STDDEV",
+    "VARIANCE"
+];
+
+impl Rule for HavingWithoutAggregate {
+    fn info(&self) -> RuleInfo {
+        RuleInfo {
+            id:       "PERF018",
+            name:     "HAVING without aggregate function",
+            severity: Severity::Warning,
+            category: RuleCategory::Performance
+        }
+    }
+
+    fn check(&self, query: &Query, query_index: usize) -> Vec<Violation> {
+        if query.query_type != QueryType::Select || query.having_cols.is_empty() {
+            return vec![];
+        }
+        let upper = query.raw.to_uppercase();
+        let Some(having_pos) = upper.find(" HAVING ") else {
+            return vec![];
+        };
+        let having_part = &upper[having_pos + " HAVING ".len()..];
+        let clause_end = [" ORDER BY ", " LIMIT ", " OFFSET "]
+            .iter()
+            .filter_map(|t| having_part.find(t))
+            .min()
+            .unwrap_or(having_part.len());
+        let clause = &having_part[..clause_end];
+        if AGGREGATE_OPENERS.iter().any(|agg| clause.contains(agg)) {
+            return vec![];
+        }
+        let info = self.info();
+        vec![Violation {
+            rule_id: info.id,
+            rule_name: info.name,
+            message: "HAVING filters plain columns after grouping".to_string(),
+            severity: info.severity,
+            category: info.category,
+            suggestion: Some(
+                "Move non-aggregate conditions into WHERE so rows are pruned before GROUP BY"
+                    .to_string()
+            ),
+            query_index
+        }]
+    }
+}
+
 /// DISTINCT with ORDER BY can be inefficient
 pub struct DistinctWithOrderBy;
 

--- a/tests/rules_tests.rs
+++ b/tests/rules_tests.rs
@@ -151,6 +151,29 @@ fn test_select_without_count_not_perf012() {
     assert!(!violations.contains(&"PERF012".to_string()));
 }
 
+#[test]
+fn test_having_without_aggregate_flagged() {
+    let violations = analyze_query(
+        "SELECT status, COUNT(*) FROM orders WHERE id > 0 GROUP BY status HAVING status = 'active' LIMIT 10"
+    );
+    assert!(violations.contains(&"PERF018".to_string()));
+}
+
+#[test]
+fn test_having_with_aggregate_ok() {
+    let violations = analyze_query(
+        "SELECT status, COUNT(*) FROM orders WHERE id > 0 GROUP BY status HAVING COUNT(*) > 10 LIMIT 10"
+    );
+    assert!(!violations.contains(&"PERF018".to_string()));
+}
+
+#[test]
+fn test_no_having_not_flagged() {
+    let violations =
+        analyze_query("SELECT status, COUNT(*) FROM orders WHERE id > 0 GROUP BY status LIMIT 10");
+    assert!(!violations.contains(&"PERF018".to_string()));
+}
+
 fn in_list_query(n: usize) -> String {
     let values: Vec<String> = (1..=n).map(|i| i.to_string()).collect();
     format!(


### PR DESCRIPTION
Closes #16

New performance rule PERF018 (Warning): flags HAVING clauses that filter plain columns — such conditions belong in WHERE so rows are pruned before GROUP BY. Clause is cut at ORDER BY/LIMIT/OFFSET; COUNT/SUM/AVG/MIN/MAX/GROUP_CONCAT/STRING_AGG/STDDEV/VARIANCE justify the HAVING and are not flagged.

- README, Cargo.toml description, docs updated to 29 rules; version bumped to 0.10.0
- 3 new tests

Local checks: fmt, clippy -D warnings, tests, cargo qual (0 issues), mdbook build — all green.