### PR TITLE
#12 feat: add PERF014 rule detecting unnecessary DISTINCT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "sql_query_analyzer"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sql_query_analyzer"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
-description = "Static analysis tool for SQL queries with 29 built-in rules for performance, security, and style"
+description = "Static analysis tool for SQL queries with 30 built-in rules for performance, security, and style"
 license = "MIT"
 repository = "https://github.com/RAprogramm/sql-query-analyzer"
 homepage = "https://github.com/RAprogramm/sql-query-analyzer"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A comprehensive SQL analysis tool that combines fast, deterministic static analy
 
 ## Highlights
 
-- **29 Built-in Rules** — Performance, style, and security checks run instantly without API calls
+- **30 Built-in Rules** — Performance, style, and security checks run instantly without API calls
 - **Schema-Aware Analysis** — Validates queries against your database schema, suggests missing indexes
 - **Multi-Dialect Support** — Generic, MySQL, PostgreSQL, SQLite, and ClickHouse with preprocessor for dialect-specific syntax
 - **Multiple Output Formats** — Text, JSON, YAML, and SARIF for CI/CD integration
@@ -100,6 +100,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql --provider openai
 | `PERF011` | Select without where | Info | Full table scan on large tables |
 | `PERF012` | COUNT(*) without WHERE | Warning | Counting every row scans the entire table |
 | `PERF013` | ORDER BY RAND() | Warning | Full scan and sort regardless of `LIMIT` |
+| `PERF014` | Unnecessary DISTINCT | Info | `DISTINCT` with `JOIN` often hides join fan-out; `DISTINCT *` escalates to Warning |
 | `PERF018` | HAVING without aggregate | Warning | Non-aggregate conditions belong in `WHERE` |
 | `PERF019` | Large IN clause | Warning | 50+ values degrade planning; severity scales with size |
 
@@ -328,7 +329,7 @@ For fast CI checks without external API calls:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-This runs all 29 built-in rules instantly without requiring any API keys.
+This runs all 30 built-in rules instantly without requiring any API keys.
 
 #### Advanced Usage
 
@@ -448,7 +449,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql
                       ▼
          ┌────────────────────────┐
          │    Static Analysis     │
-         │  (29 rules, parallel)  │
+         │  (30 rules, parallel)  │
          └────────────┬───────────┘
                       │
                       ▼

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -16,7 +16,7 @@ reach production.
 
 ## Highlights
 
-- **29 built-in rules** across performance, style, security, and schema-aware
+- **30 built-in rules** across performance, style, security, and schema-aware
   categories
 - **Schema-aware analysis** — detects missing indexes and unknown columns by
   parsing your `CREATE TABLE` statements

--- a/docs/src/rules/index.md
+++ b/docs/src/rules/index.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Rules Overview
 
-29 built-in rules across four categories. Every rule has a stable ID, a default
+30 built-in rules across four categories. Every rule has a stable ID, a default
 severity, and a suggestion attached to each violation. Rules can be disabled or
 re-weighted via [configuration](../configuration.md).
 

--- a/docs/src/rules/performance.md
+++ b/docs/src/rules/performance.md
@@ -148,6 +148,23 @@ LIMIT 5;
 SELECT * FROM products ORDER BY random_sort LIMIT 5;
 ```
 
+## PERF014 — Potentially unnecessary DISTINCT (Info)
+
+`DISTINCT` combined with `JOIN` usually hides duplicate rows produced by join
+fan-out; deduplication then costs a sort or hash over the whole result.
+`SELECT DISTINCT *` escalates to Warning.
+
+```sql
+-- Flagged (Info): fix the join instead of deduplicating
+SELECT DISTINCT u.name FROM users u JOIN orders o ON o.user_id = u.id;
+
+-- Flagged (Warning)
+SELECT DISTINCT * FROM users u JOIN orders o ON o.user_id = u.id;
+
+-- Not flagged: unique-value enumeration on one table
+SELECT DISTINCT status FROM orders;
+```
+
 ## PERF018 — HAVING without aggregate (Warning)
 
 `HAVING` filters after grouping; a condition on plain columns forces the

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -203,6 +203,7 @@ impl RuleRunner {
             Box::new(performance::CountWithoutWhere),
             Box::new(performance::LargeInClause),
             Box::new(performance::HavingWithoutAggregate),
+            Box::new(performance::UnnecessaryDistinct),
             Box::new(style::SelectStar),
             Box::new(style::MissingTableAlias),
             Box::new(style::OrdinalInOrderOrGroupBy),

--- a/src/rules/performance.rs
+++ b/src/rules/performance.rs
@@ -606,6 +606,61 @@ impl Rule for HavingWithoutAggregate {
     }
 }
 
+/// DISTINCT that likely papers over a join fan-out
+///
+/// DISTINCT combined with JOIN usually hides duplicate rows produced by a
+/// missing or too-loose join condition; deduplication then costs a sort or
+/// hash over the whole result. `SELECT DISTINCT *` escalates to Warning —
+/// deduplicating entire rows is almost never intended.
+pub struct UnnecessaryDistinct;
+
+impl Rule for UnnecessaryDistinct {
+    fn info(&self) -> RuleInfo {
+        RuleInfo {
+            id:       "PERF014",
+            name:     "Potentially unnecessary DISTINCT",
+            severity: Severity::Info,
+            category: RuleCategory::Performance
+        }
+    }
+
+    fn check(&self, query: &Query, query_index: usize) -> Vec<Violation> {
+        if query.query_type != QueryType::Select || !query.has_distinct {
+            return vec![];
+        }
+        let upper = query.raw.to_uppercase();
+        let distinct_star = upper.contains("SELECT DISTINCT *");
+        let distinct_with_join = query.tables.len() > 1;
+        if !distinct_star && !distinct_with_join {
+            return vec![];
+        }
+        let info = self.info();
+        let (severity, message) = if distinct_star {
+            (
+                Severity::Warning,
+                "SELECT DISTINCT * deduplicates entire rows".to_string()
+            )
+        } else {
+            (
+                info.severity,
+                "DISTINCT combined with JOIN often hides join fan-out".to_string()
+            )
+        };
+        vec![Violation {
+            rule_id: info.id,
+            rule_name: info.name,
+            message,
+            severity,
+            category: info.category,
+            suggestion: Some(
+                "Check the join conditions for fan-out before deduplicating; select explicit columns instead of DISTINCT *"
+                    .to_string()
+            ),
+            query_index
+        }]
+    }
+}
+
 /// DISTINCT with ORDER BY can be inefficient
 pub struct DistinctWithOrderBy;
 

--- a/tests/rules_tests.rs
+++ b/tests/rules_tests.rs
@@ -152,6 +152,36 @@ fn test_select_without_count_not_perf012() {
 }
 
 #[test]
+fn test_distinct_with_join_flagged() {
+    let violations = analyze_query(
+        "SELECT DISTINCT u.name FROM users u JOIN orders o ON o.user_id = u.id WHERE u.id > 0 LIMIT 10"
+    );
+    assert!(violations.contains(&"PERF014".to_string()));
+}
+
+#[test]
+fn test_distinct_star_is_warning() {
+    let queries = parse_queries(
+        "SELECT DISTINCT * FROM users u JOIN orders o ON o.user_id = u.id WHERE u.id > 0 LIMIT 10",
+        SqlDialect::Generic
+    )
+    .unwrap();
+    let report = RuleRunner::new().analyze(&queries);
+    let violation = report
+        .violations
+        .iter()
+        .find(|v| v.rule_id == "PERF014")
+        .unwrap();
+    assert_eq!(violation.severity, Severity::Warning);
+}
+
+#[test]
+fn test_distinct_single_table_ok() {
+    let violations = analyze_query("SELECT DISTINCT status FROM orders WHERE id > 0 LIMIT 10");
+    assert!(!violations.contains(&"PERF014".to_string()));
+}
+
+#[test]
 fn test_having_without_aggregate_flagged() {
     let violations = analyze_query(
         "SELECT status, COUNT(*) FROM orders WHERE id > 0 GROUP BY status HAVING status = 'active' LIMIT 10"


### PR DESCRIPTION
Closes #12

New performance rule PERF014 (Info): flags DISTINCT combined with JOIN — usually a symptom of join fan-out rather than an intentional deduplication. SELECT DISTINCT * escalates to Warning. Single-table DISTINCT enumeration is not flagged.

- README, Cargo.toml description, docs updated to 30 rules; version bumped to 0.11.0
- 3 new tests incl. severity escalation

Local checks: fmt, clippy -D warnings, tests, cargo qual (0 issues), mdbook build — all green.