### PR TITLE
#18 feat: add PERF020 rule detecting deeply nested subqueries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "sql_query_analyzer"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sql_query_analyzer"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
-description = "Static analysis tool for SQL queries with 30 built-in rules for performance, security, and style"
+description = "Static analysis tool for SQL queries with 31 built-in rules for performance, security, and style"
 license = "MIT"
 repository = "https://github.com/RAprogramm/sql-query-analyzer"
 homepage = "https://github.com/RAprogramm/sql-query-analyzer"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A comprehensive SQL analysis tool that combines fast, deterministic static analy
 
 ## Highlights
 
-- **30 Built-in Rules** — Performance, style, and security checks run instantly without API calls
+- **31 Built-in Rules** — Performance, style, and security checks run instantly without API calls
 - **Schema-Aware Analysis** — Validates queries against your database schema, suggests missing indexes
 - **Multi-Dialect Support** — Generic, MySQL, PostgreSQL, SQLite, and ClickHouse with preprocessor for dialect-specific syntax
 - **Multiple Output Formats** — Text, JSON, YAML, and SARIF for CI/CD integration
@@ -103,6 +103,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql --provider openai
 | `PERF014` | Unnecessary DISTINCT | Info | `DISTINCT` with `JOIN` often hides join fan-out; `DISTINCT *` escalates to Warning |
 | `PERF018` | HAVING without aggregate | Warning | Non-aggregate conditions belong in `WHERE` |
 | `PERF019` | Large IN clause | Warning | 50+ values degrade planning; severity scales with size |
+| `PERF020` | Deeply nested subqueries | Warning | 3+ SELECT levels; severity scales with depth |
 
 ### Style Rules
 
@@ -329,7 +330,7 @@ For fast CI checks without external API calls:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-This runs all 30 built-in rules instantly without requiring any API keys.
+This runs all 31 built-in rules instantly without requiring any API keys.
 
 #### Advanced Usage
 
@@ -449,7 +450,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql
                       ▼
          ┌────────────────────────┐
          │    Static Analysis     │
-         │  (30 rules, parallel)  │
+         │  (31 rules, parallel)  │
          └────────────┬───────────┘
                       │
                       ▼

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -16,7 +16,7 @@ reach production.
 
 ## Highlights
 
-- **30 built-in rules** across performance, style, security, and schema-aware
+- **31 built-in rules** across performance, style, security, and schema-aware
   categories
 - **Schema-aware analysis** — detects missing indexes and unknown columns by
   parsing your `CREATE TABLE` statements

--- a/docs/src/rules/index.md
+++ b/docs/src/rules/index.md
@@ -5,13 +5,13 @@ SPDX-License-Identifier: MIT
 
 # Rules Overview
 
-30 built-in rules across four categories. Every rule has a stable ID, a default
+31 built-in rules across four categories. Every rule has a stable ID, a default
 severity, and a suggestion attached to each violation. Rules can be disabled or
 re-weighted via [configuration](../configuration.md).
 
 | Category | IDs | Focus |
 |----------|-----|-------|
-| [Performance](performance.md) | `PERF001`–`PERF019` | Index usage, table scans, N+1 patterns |
+| [Performance](performance.md) | `PERF001`–`PERF020` | Index usage, table scans, N+1 patterns |
 | [Style](style.md) | `STYLE001`–`STYLE004` | Readability and maintainability |
 | [Security](security.md) | `SEC001`–`SEC008` | Destructive statements without guards |
 | [Schema-Aware](schema.md) | `SCHEMA001`–`SCHEMA003` | Cross-checking queries against DDL |

--- a/docs/src/rules/performance.md
+++ b/docs/src/rules/performance.md
@@ -194,3 +194,20 @@ SELECT * FROM users WHERE id IN (1, 2, 3, /* …60 more… */ 64);
 
 -- Better: JOIN against a temporary table, or batch the lookups
 ```
+
+## PERF020 — Deeply nested subqueries (Warning)
+
+Each nesting level multiplies planning complexity and usually hides a JOIN or
+CTE that would express the same logic flatter. Severity scales with total
+SELECT depth: three levels is Info, four Warning, five or more Error.
+
+```sql
+-- Flagged (3 levels)
+SELECT * FROM a WHERE x IN (
+    SELECT y FROM b WHERE z IN (SELECT w FROM c WHERE v = 1));
+
+-- Better: name the steps
+WITH matching_c AS (SELECT w FROM c WHERE v = 1),
+     matching_b AS (SELECT y FROM b JOIN matching_c ON b.z = matching_c.w)
+SELECT a.* FROM a JOIN matching_b ON a.x = matching_b.y;
+```

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -23,7 +23,7 @@
 //!
 //! # Rule Categories
 //!
-//! - **Performance** (`PERF001`-`PERF019`) - Query optimization issues
+//! - **Performance** (`PERF001`-`PERF020`) - Query optimization issues
 //! - **Style** (`STYLE001`-`STYLE004`) - Best practice violations
 //! - **Security** (`SEC001`-`SEC008`) - Dangerous operations
 //! - **Schema** (`SCHEMA001`-`SCHEMA003`) - Schema validation (requires schema)
@@ -183,7 +183,7 @@ impl RuleRunner {
     ///
     /// # Notes
     ///
-    /// - Performance rules (PERF001-PERF019) detect query optimization issues
+    /// - Performance rules (PERF001-PERF020) detect query optimization issues
     /// - Style rules (STYLE001-STYLE004) enforce best practices
     /// - Security rules (SEC001-SEC008) detect dangerous operations
     pub fn with_config(config: RulesConfig) -> Self {
@@ -204,6 +204,7 @@ impl RuleRunner {
             Box::new(performance::LargeInClause),
             Box::new(performance::HavingWithoutAggregate),
             Box::new(performance::UnnecessaryDistinct),
+            Box::new(performance::DeeplyNestedSubqueries),
             Box::new(style::SelectStar),
             Box::new(style::MissingTableAlias),
             Box::new(style::OrdinalInOrderOrGroupBy),

--- a/src/rules/performance.rs
+++ b/src/rules/performance.rs
@@ -661,6 +661,83 @@ impl Rule for UnnecessaryDistinct {
     }
 }
 
+/// Deeply nested subqueries defeat optimizers and readers alike
+///
+/// Each nesting level multiplies planning complexity and usually hides a
+/// JOIN or CTE that would express the same logic flatter and faster.
+/// Severity scales with total SELECT depth: three levels is Info, four
+/// Warning, five or more Error.
+pub struct DeeplyNestedSubqueries;
+
+/// Returns the deepest count of parenthesized SELECTs enclosing each other.
+fn max_subquery_depth(upper: &str) -> usize {
+    let bytes = upper.as_bytes();
+    let mut select_stack: Vec<usize> = Vec::new();
+    let mut paren_depth = 0usize;
+    let mut max_depth = 0usize;
+    for (i, b) in bytes.iter().enumerate() {
+        match b {
+            b'(' => {
+                paren_depth += 1;
+                if upper[i + 1..].trim_start().starts_with("SELECT") {
+                    select_stack.push(paren_depth);
+                    max_depth = max_depth.max(select_stack.len());
+                }
+            }
+            b')' => {
+                if select_stack.last() == Some(&paren_depth) {
+                    select_stack.pop();
+                }
+                paren_depth = paren_depth.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+    max_depth
+}
+
+impl Rule for DeeplyNestedSubqueries {
+    fn info(&self) -> RuleInfo {
+        RuleInfo {
+            id:       "PERF020",
+            name:     "Deeply nested subqueries",
+            severity: Severity::Warning,
+            category: RuleCategory::Performance
+        }
+    }
+
+    fn check(&self, query: &Query, query_index: usize) -> Vec<Violation> {
+        if query.query_type != QueryType::Select {
+            return vec![];
+        }
+        let upper = query.raw.to_uppercase();
+        let levels = max_subquery_depth(&upper) + 1;
+        if levels < 3 {
+            return vec![];
+        }
+        let severity = if levels >= 5 {
+            Severity::Error
+        } else if levels >= 4 {
+            Severity::Warning
+        } else {
+            Severity::Info
+        };
+        let info = self.info();
+        vec![Violation {
+            rule_id: info.id,
+            rule_name: info.name,
+            message: format!("Query nests SELECTs {} levels deep", levels),
+            severity,
+            category: info.category,
+            suggestion: Some(
+                "Flatten nested subqueries into JOINs or name the steps with CTEs (WITH ...)"
+                    .to_string()
+            ),
+            query_index
+        }]
+    }
+}
+
 /// DISTINCT with ORDER BY can be inefficient
 pub struct DistinctWithOrderBy;
 

--- a/tests/rules_tests.rs
+++ b/tests/rules_tests.rs
@@ -204,6 +204,45 @@ fn test_no_having_not_flagged() {
     assert!(!violations.contains(&"PERF018".to_string()));
 }
 
+#[test]
+fn test_three_level_nesting_flagged_info() {
+    let queries = parse_queries(
+        "SELECT id FROM a WHERE x IN (SELECT y FROM b WHERE z IN (SELECT w FROM c WHERE v = 1)) LIMIT 10",
+        SqlDialect::Generic
+    )
+    .unwrap();
+    let report = RuleRunner::new().analyze(&queries);
+    let violation = report
+        .violations
+        .iter()
+        .find(|v| v.rule_id == "PERF020")
+        .unwrap();
+    assert_eq!(violation.severity, Severity::Info);
+}
+
+#[test]
+fn test_single_subquery_not_flagged() {
+    let violations =
+        analyze_query("SELECT id FROM a WHERE x IN (SELECT y FROM b WHERE z = 1) LIMIT 10");
+    assert!(!violations.contains(&"PERF020".to_string()));
+}
+
+#[test]
+fn test_five_level_nesting_is_error() {
+    let queries = parse_queries(
+        "SELECT id FROM a WHERE x IN (SELECT y FROM b WHERE z IN (SELECT w FROM c WHERE v IN (SELECT u FROM d WHERE t IN (SELECT s FROM e WHERE r = 1)))) LIMIT 10",
+        SqlDialect::Generic
+    )
+    .unwrap();
+    let report = RuleRunner::new().analyze(&queries);
+    let violation = report
+        .violations
+        .iter()
+        .find(|v| v.rule_id == "PERF020")
+        .unwrap();
+    assert_eq!(violation.severity, Severity::Error);
+}
+
 fn in_list_query(n: usize) -> String {
     let values: Vec<String> = (1..=n).map(|i| i.to_string()).collect();
     format!(


### PR DESCRIPTION
Closes #18

New performance rule PERF020: flags queries nesting SELECTs three or more levels deep; severity scales with depth (3 Info, 4 Warning, 5+ Error). Depth is measured by tracking parenthesized SELECT openings against paren depth, so sibling subqueries do not inflate the count.

- README, Cargo.toml description, docs updated to 31 rules; version bumped to 0.12.0
- 3 new tests: Info at 3 levels, negative at 2, Error at 5

Local checks: fmt, clippy -D warnings, tests, cargo qual (0 issues), mdbook build — all green.