### PR TITLE
#21 feat: add SCHEMA004 rule detecting JOIN on non-indexed column

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "sql_query_analyzer"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sql_query_analyzer"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
-description = "Static analysis tool for SQL queries with 31 built-in rules for performance, security, and style"
+description = "Static analysis tool for SQL queries with 32 built-in rules for performance, security, and style"
 license = "MIT"
 repository = "https://github.com/RAprogramm/sql-query-analyzer"
 homepage = "https://github.com/RAprogramm/sql-query-analyzer"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A comprehensive SQL analysis tool that combines fast, deterministic static analy
 
 ## Highlights
 
-- **31 Built-in Rules** — Performance, style, and security checks run instantly without API calls
+- **32 Built-in Rules** — Performance, style, and security checks run instantly without API calls
 - **Schema-Aware Analysis** — Validates queries against your database schema, suggests missing indexes
 - **Multi-Dialect Support** — Generic, MySQL, PostgreSQL, SQLite, and ClickHouse with preprocessor for dialect-specific syntax
 - **Multiple Output Formats** — Text, JSON, YAML, and SARIF for CI/CD integration
@@ -133,6 +133,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql --provider openai
 | `SCHEMA001` | Missing index on filter | Warning | WHERE/JOIN column lacks index |
 | `SCHEMA002` | Column not in schema | Warning | Referenced column doesn't exist |
 | `SCHEMA003` | Index suggestion | Info | ORDER BY column could benefit from index |
+| `SCHEMA004` | JOIN on non-indexed column | Warning | JOIN column must lead an index of its own table |
 
 <div align="right"><a href="#table-of-contents">↑ Back to top</a></div>
 
@@ -330,7 +331,7 @@ For fast CI checks without external API calls:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-This runs all 31 built-in rules instantly without requiring any API keys.
+This runs all 32 built-in rules instantly without requiring any API keys.
 
 #### Advanced Usage
 
@@ -450,7 +451,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql
                       ▼
          ┌────────────────────────┐
          │    Static Analysis     │
-         │  (31 rules, parallel)  │
+         │  (32 rules, parallel)  │
          └────────────┬───────────┘
                       │
                       ▼

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -16,7 +16,7 @@ reach production.
 
 ## Highlights
 
-- **31 built-in rules** across performance, style, security, and schema-aware
+- **32 built-in rules** across performance, style, security, and schema-aware
   categories
 - **Schema-aware analysis** — detects missing indexes and unknown columns by
   parsing your `CREATE TABLE` statements

--- a/docs/src/rules/index.md
+++ b/docs/src/rules/index.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Rules Overview
 
-31 built-in rules across four categories. Every rule has a stable ID, a default
+32 built-in rules across four categories. Every rule has a stable ID, a default
 severity, and a suggestion attached to each violation. Rules can be disabled or
 re-weighted via [configuration](../configuration.md).
 
@@ -14,7 +14,7 @@ re-weighted via [configuration](../configuration.md).
 | [Performance](performance.md) | `PERF001`–`PERF020` | Index usage, table scans, N+1 patterns |
 | [Style](style.md) | `STYLE001`–`STYLE004` | Readability and maintainability |
 | [Security](security.md) | `SEC001`–`SEC008` | Destructive statements without guards |
-| [Schema-Aware](schema.md) | `SCHEMA001`–`SCHEMA003` | Cross-checking queries against DDL |
+| [Schema-Aware](schema.md) | `SCHEMA001`–`SCHEMA004` | Cross-checking queries against DDL |
 
 ## Severities
 

--- a/docs/src/rules/schema.md
+++ b/docs/src/rules/schema.md
@@ -33,3 +33,21 @@ usually a typo or a stale query after a migration.
 
 An `ORDER BY` column without an index forces a sort; with one, rows can be
 read in order.
+
+## SCHEMA004 — JOIN on non-indexed column (Warning)
+
+Stricter than SCHEMA001: the join column must exist in the joined table and
+be the **leading** column of one of that table's indexes — an index elsewhere
+in the schema with the same column name does not help this join.
+
+```sql
+-- schema.sql
+CREATE TABLE users (id INT PRIMARY KEY);
+CREATE TABLE orders (id INT PRIMARY KEY, user_id INT);
+
+-- Flagged: orders.user_id leads no index
+SELECT u.id FROM users u JOIN orders o ON o.user_id = u.id;
+
+-- Fix
+CREATE INDEX idx_orders_user_id ON orders (user_id);
+```

--- a/src/query/extract/set_expr.rs
+++ b/src/query/extract/set_expr.rs
@@ -28,8 +28,11 @@ pub fn extract_from_set_expr(set_expr: &sqlparser::ast::SetExpr, ctx: &mut Extra
                 for join in &table.joins {
                     extract_from_table_factor(&join.relation, ctx.tables);
                     match &join.join_operator {
-                        sqlparser::ast::JoinOperator::Inner(constraint)
+                        sqlparser::ast::JoinOperator::Join(constraint)
+                        | sqlparser::ast::JoinOperator::Inner(constraint)
+                        | sqlparser::ast::JoinOperator::Left(constraint)
                         | sqlparser::ast::JoinOperator::LeftOuter(constraint)
+                        | sqlparser::ast::JoinOperator::Right(constraint)
                         | sqlparser::ast::JoinOperator::RightOuter(constraint)
                         | sqlparser::ast::JoinOperator::FullOuter(constraint) => {
                             if let sqlparser::ast::JoinConstraint::On(expr) = constraint {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -26,7 +26,7 @@
 //! - **Performance** (`PERF001`-`PERF020`) - Query optimization issues
 //! - **Style** (`STYLE001`-`STYLE004`) - Best practice violations
 //! - **Security** (`SEC001`-`SEC008`) - Dangerous operations
-//! - **Schema** (`SCHEMA001`-`SCHEMA003`) - Schema validation (requires schema)
+//! - **Schema** (`SCHEMA001`-`SCHEMA004`) - Schema validation (requires schema)
 //!
 //! # Configuration
 //!
@@ -245,7 +245,7 @@ impl RuleRunner {
     ///
     /// # Notes
     ///
-    /// - Adds schema-aware rules (SCHEMA001-SCHEMA003) if not disabled
+    /// - Adds schema-aware rules (SCHEMA001-SCHEMA004) if not disabled
     /// - Updates severity cache for schema rules
     pub fn with_schema_and_config(schema: Schema, config: RulesConfig) -> Self {
         let mut runner = Self::with_config(config.clone());
@@ -254,7 +254,8 @@ impl RuleRunner {
                 schema.clone()
             )),
             Box::new(schema_aware::ColumnNotInSchema::new(schema.clone())),
-            Box::new(schema_aware::SuggestIndex::new(schema)),
+            Box::new(schema_aware::SuggestIndex::new(schema.clone())),
+            Box::new(schema_aware::JoinOnNonIndexedColumn::new(schema)),
         ];
         for rule in schema_rules {
             if !config

--- a/src/rules/schema_aware.rs
+++ b/src/rules/schema_aware.rs
@@ -139,6 +139,90 @@ impl Rule for ColumnNotInSchema {
     }
 }
 
+/// JOIN columns must lead an index of their own table
+///
+/// SCHEMA001 only asks whether a column name is indexed anywhere in the
+/// schema; a join still degrades to a per-row scan when the joined table
+/// itself lacks an index that starts with the join column. This rule checks
+/// the joined tables precisely: the column must exist in the table and be
+/// the leading column of one of that table's indexes.
+pub struct JoinOnNonIndexedColumn {
+    schema: Schema
+}
+
+impl JoinOnNonIndexedColumn {
+    pub fn new(schema: Schema) -> Self {
+        Self {
+            schema
+        }
+    }
+}
+
+impl Rule for JoinOnNonIndexedColumn {
+    fn info(&self) -> RuleInfo {
+        RuleInfo {
+            id:       "SCHEMA004",
+            name:     "JOIN on non-indexed column",
+            severity: Severity::Warning,
+            category: RuleCategory::Performance
+        }
+    }
+
+    fn check(&self, query: &Query, query_index: usize) -> Vec<Violation> {
+        if query.query_type != QueryType::Select || query.join_cols.is_empty() {
+            return vec![];
+        }
+        let mut violations = Vec::new();
+        for table_name in &query.tables {
+            let Some(table) = self
+                .schema
+                .tables
+                .values()
+                .find(|t| t.name.eq_ignore_ascii_case(table_name))
+            else {
+                continue;
+            };
+            for col in &query.join_cols {
+                let Some(column) = table
+                    .columns
+                    .iter()
+                    .find(|c| c.name.eq_ignore_ascii_case(col))
+                else {
+                    continue;
+                };
+                let leads_index = column.is_primary
+                    || table.indexes.iter().any(|idx| {
+                        idx.columns
+                            .first()
+                            .is_some_and(|first| first.eq_ignore_ascii_case(col))
+                    });
+                if !leads_index {
+                    let info = self.info();
+                    violations.push(Violation {
+                        rule_id: info.id,
+                        rule_name: info.name,
+                        message: format!(
+                            "JOIN column '{}' of table '{}' does not lead any index",
+                            col, table.name
+                        ),
+                        severity: info.severity,
+                        category: info.category,
+                        suggestion: Some(format!(
+                            "CREATE INDEX idx_{}_{} ON {}({})",
+                            table.name.to_lowercase(),
+                            col.to_lowercase(),
+                            table.name,
+                            col
+                        )),
+                        query_index
+                    });
+                }
+            }
+        }
+        violations
+    }
+}
+
 /// Suggest indexes based on query patterns
 pub struct SuggestIndex {
     schema: Schema

--- a/src/rules/schema_aware.rs
+++ b/src/rules/schema_aware.rs
@@ -208,11 +208,11 @@ impl Rule for JoinOnNonIndexedColumn {
                         severity: info.severity,
                         category: info.category,
                         suggestion: Some(format!(
-                            "CREATE INDEX idx_{}_{} ON {}({})",
-                            table.name.to_lowercase(),
-                            col.to_lowercase(),
-                            table.name,
-                            col
+                            "CREATE INDEX idx_{table_lower}_{col_lower} ON {table}({col})",
+                            table_lower = table.name.to_lowercase(),
+                            col_lower = col.to_lowercase(),
+                            table = table.name,
+                            col = col
                         )),
                         query_index
                     });

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -502,3 +502,17 @@ fn test_clickhouse_format_datetime() {
     let queries = parse_queries(sql, SqlDialect::ClickHouse).unwrap();
     assert_eq!(queries.len(), 1);
 }
+
+#[test]
+fn test_plain_join_extracts_join_cols() {
+    let sql = "SELECT u.id FROM users u JOIN orders o ON o.user_id = u.id";
+    let queries = parse_queries(sql, SqlDialect::Generic).unwrap();
+    assert!(!queries[0].join_cols.is_empty());
+}
+
+#[test]
+fn test_left_join_extracts_join_cols() {
+    let sql = "SELECT u.id FROM users u LEFT JOIN orders o ON o.user_id = u.id";
+    let queries = parse_queries(sql, SqlDialect::Generic).unwrap();
+    assert!(!queries[0].join_cols.is_empty());
+}

--- a/tests/rules_tests.rs
+++ b/tests/rules_tests.rs
@@ -471,6 +471,33 @@ fn test_distinct_with_order_by() {
 }
 
 #[test]
+fn test_join_on_non_indexed_column_flagged() {
+    let schema = r#"
+        CREATE TABLE users (id INT PRIMARY KEY);
+        CREATE TABLE orders (id INT PRIMARY KEY, user_id INT);
+    "#;
+    let violations = analyze_with_schema(
+        "SELECT u.id FROM users u JOIN orders o ON o.user_id = u.id WHERE u.id > 0 LIMIT 10",
+        schema
+    );
+    assert!(violations.contains(&"SCHEMA004".to_string()));
+}
+
+#[test]
+fn test_join_on_indexed_column_ok() {
+    let schema = r#"
+        CREATE TABLE users (id INT PRIMARY KEY);
+        CREATE TABLE orders (id INT PRIMARY KEY, user_id INT);
+        CREATE INDEX idx_orders_user_id ON orders(user_id);
+    "#;
+    let violations = analyze_with_schema(
+        "SELECT u.id FROM users u JOIN orders o ON o.user_id = u.id WHERE u.id > 0 LIMIT 10",
+        schema
+    );
+    assert!(!violations.contains(&"SCHEMA004".to_string()));
+}
+
+#[test]
 fn test_schema_missing_index() {
     let schema = "CREATE TABLE users (id INT PRIMARY KEY, email VARCHAR(255))";
     let violations = analyze_with_schema(


### PR DESCRIPTION
Closes #21

New schema-aware rule SCHEMA004 (Warning): a JOIN column must exist in the joined table and lead one of that table's indexes (or be its primary key) — stricter than SCHEMA001, which only checks the column name against indexes anywhere in the schema.

Also fixes a real regression the new rule's test caught: since the sqlparser upgrade, plain JOIN / LEFT JOIN / RIGHT JOIN parse as JoinOperator::Join/Left/Right, which the extractor did not match — join_cols was always empty, silently blinding every join-based check (SCHEMA001 join branch, STYLE002, PERF006). Fixed in a separate commit with regression tests.

- README, Cargo.toml description, docs updated to 32 rules; version bumped to 0.13.0
- 4 new tests (2 rule, 2 extractor regression); suite grew 465→470 as join branches came alive

Local checks: fmt, clippy -D warnings, 470 tests, cargo qual (0 issues), mdbook build — all green.