### PR TITLE
#13 feat: add PERF015 rule detecting implicit type conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "sql_query_analyzer"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sql_query_analyzer"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
-description = "Static analysis tool for SQL queries with 32 built-in rules for performance, security, and style"
+description = "Static analysis tool for SQL queries with 33 built-in rules for performance, security, and style"
 license = "MIT"
 repository = "https://github.com/RAprogramm/sql-query-analyzer"
 homepage = "https://github.com/RAprogramm/sql-query-analyzer"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A comprehensive SQL analysis tool that combines fast, deterministic static analy
 
 ## Highlights
 
-- **32 Built-in Rules** — Performance, style, and security checks run instantly without API calls
+- **33 Built-in Rules** — Performance, style, and security checks run instantly without API calls
 - **Schema-Aware Analysis** — Validates queries against your database schema, suggests missing indexes
 - **Multi-Dialect Support** — Generic, MySQL, PostgreSQL, SQLite, and ClickHouse with preprocessor for dialect-specific syntax
 - **Multiple Output Formats** — Text, JSON, YAML, and SARIF for CI/CD integration
@@ -101,6 +101,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql --provider openai
 | `PERF012` | COUNT(*) without WHERE | Warning | Counting every row scans the entire table |
 | `PERF013` | ORDER BY RAND() | Warning | Full scan and sort regardless of `LIMIT` |
 | `PERF014` | Unnecessary DISTINCT | Info | `DISTINCT` with `JOIN` often hides join fan-out; `DISTINCT *` escalates to Warning |
+| `PERF015` | Implicit type conversion | Warning | Text column compared with numeric literal disables its index (needs schema) |
 | `PERF018` | HAVING without aggregate | Warning | Non-aggregate conditions belong in `WHERE` |
 | `PERF019` | Large IN clause | Warning | 50+ values degrade planning; severity scales with size |
 | `PERF020` | Deeply nested subqueries | Warning | 3+ SELECT levels; severity scales with depth |
@@ -331,7 +332,7 @@ For fast CI checks without external API calls:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-This runs all 32 built-in rules instantly without requiring any API keys.
+This runs all 33 built-in rules instantly without requiring any API keys.
 
 #### Advanced Usage
 
@@ -451,7 +452,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql
                       ▼
          ┌────────────────────────┐
          │    Static Analysis     │
-         │  (32 rules, parallel)  │
+         │  (33 rules, parallel)  │
          └────────────┬───────────┘
                       │
                       ▼

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -16,7 +16,7 @@ reach production.
 
 ## Highlights
 
-- **32 built-in rules** across performance, style, security, and schema-aware
+- **33 built-in rules** across performance, style, security, and schema-aware
   categories
 - **Schema-aware analysis** — detects missing indexes and unknown columns by
   parsing your `CREATE TABLE` statements

--- a/docs/src/rules/index.md
+++ b/docs/src/rules/index.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Rules Overview
 
-32 built-in rules across four categories. Every rule has a stable ID, a default
+33 built-in rules across four categories. Every rule has a stable ID, a default
 severity, and a suggestion attached to each violation. Rules can be disabled or
 re-weighted via [configuration](../configuration.md).
 

--- a/docs/src/rules/performance.md
+++ b/docs/src/rules/performance.md
@@ -165,6 +165,23 @@ SELECT DISTINCT * FROM users u JOIN orders o ON o.user_id = u.id;
 SELECT DISTINCT status FROM orders;
 ```
 
+## PERF015 — Implicit type conversion (Warning, needs schema)
+
+Comparing a text column to a bare number forces a cast on every row; on most
+engines the column side is cast, which disables its index and can silently
+change matching semantics.
+
+```sql
+-- schema.sql
+CREATE TABLE users (id INT PRIMARY KEY, phone VARCHAR(20));
+
+-- Flagged
+SELECT id FROM users WHERE phone = 5551234;
+
+-- Better
+SELECT id FROM users WHERE phone = '5551234';
+```
+
 ## PERF018 — HAVING without aggregate (Warning)
 
 `HAVING` filters after grouping; a condition on plain columns forces the

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -255,7 +255,8 @@ impl RuleRunner {
             )),
             Box::new(schema_aware::ColumnNotInSchema::new(schema.clone())),
             Box::new(schema_aware::SuggestIndex::new(schema.clone())),
-            Box::new(schema_aware::JoinOnNonIndexedColumn::new(schema)),
+            Box::new(schema_aware::JoinOnNonIndexedColumn::new(schema.clone())),
+            Box::new(schema_aware::ImplicitTypeConversion::new(schema)),
         ];
         for rule in schema_rules {
             if !config

--- a/src/rules/schema_aware.rs
+++ b/src/rules/schema_aware.rs
@@ -223,6 +223,102 @@ impl Rule for JoinOnNonIndexedColumn {
     }
 }
 
+/// String column compared with a bare numeric literal
+///
+/// Comparing a text column to a number forces the engine to cast one side
+/// on every row; on most engines the column side is cast, which disables
+/// its index and can silently change matching semantics.
+pub struct ImplicitTypeConversion {
+    schema: Schema
+}
+
+impl ImplicitTypeConversion {
+    pub fn new(schema: Schema) -> Self {
+        Self {
+            schema
+        }
+    }
+
+    fn text_columns(&self) -> Vec<String> {
+        self.schema
+            .tables
+            .values()
+            .flat_map(|t| t.columns.iter())
+            .filter(|c| {
+                let ty = c.data_type.to_uppercase();
+                ty.contains("CHAR") || ty.contains("TEXT")
+            })
+            .map(|c| c.name.to_uppercase())
+            .collect()
+    }
+}
+
+/// Returns true when `upper` compares `col` to a bare numeric literal
+/// (`col = 123`), i.e. the token after `=` starts with a digit and no quote.
+fn compares_column_to_number(upper: &str, col: &str) -> bool {
+    upper.match_indices(col).any(|(pos, _)| {
+        if pos > 0 {
+            let prev = upper.as_bytes()[pos - 1];
+            if prev.is_ascii_alphanumeric() || prev == b'_' || prev == b'.' {
+                return false;
+            }
+        }
+        let after = &upper[pos + col.len()..];
+        let Some(rest) = after.trim_start().strip_prefix('=') else {
+            return false;
+        };
+        rest.trim_start()
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_digit())
+    })
+}
+
+impl Rule for ImplicitTypeConversion {
+    fn info(&self) -> RuleInfo {
+        RuleInfo {
+            id:       "PERF015",
+            name:     "Implicit type conversion",
+            severity: Severity::Warning,
+            category: RuleCategory::Performance
+        }
+    }
+
+    fn check(&self, query: &Query, query_index: usize) -> Vec<Violation> {
+        if query.where_cols.is_empty() {
+            return vec![];
+        }
+        let upper = query.raw.to_uppercase();
+        let text_cols = self.text_columns();
+        let mut violations = Vec::new();
+        for col in &query.where_cols {
+            let col_upper = col.to_uppercase();
+            if !text_cols.iter().any(|c| *c == col_upper) {
+                continue;
+            }
+            if compares_column_to_number(&upper, &col_upper) {
+                let info = self.info();
+                violations.push(Violation {
+                    rule_id: info.id,
+                    rule_name: info.name,
+                    message: format!(
+                        "Text column '{}' is compared with a numeric literal",
+                        col
+                    ),
+                    severity: info.severity,
+                    category: info.category,
+                    suggestion: Some(
+                        "Quote the literal to match the column type; implicit casts disable indexes"
+                            .to_string()
+                    ),
+                    query_index
+                });
+            }
+        }
+        violations
+    }
+}
+
 /// Suggest indexes based on query patterns
 pub struct SuggestIndex {
     schema: Schema

--- a/tests/rules_tests.rs
+++ b/tests/rules_tests.rs
@@ -498,6 +498,33 @@ fn test_join_on_indexed_column_ok() {
 }
 
 #[test]
+fn test_implicit_conversion_flagged() {
+    let schema = "CREATE TABLE users (id INT PRIMARY KEY, phone VARCHAR(20))";
+    let violations = analyze_with_schema(
+        "SELECT id FROM users WHERE phone = 5551234 LIMIT 10",
+        schema
+    );
+    assert!(violations.contains(&"PERF015".to_string()));
+}
+
+#[test]
+fn test_quoted_literal_no_conversion() {
+    let schema = "CREATE TABLE users (id INT PRIMARY KEY, phone VARCHAR(20))";
+    let violations = analyze_with_schema(
+        "SELECT id FROM users WHERE phone = '5551234' LIMIT 10",
+        schema
+    );
+    assert!(!violations.contains(&"PERF015".to_string()));
+}
+
+#[test]
+fn test_numeric_column_comparison_ok() {
+    let schema = "CREATE TABLE users (id INT PRIMARY KEY, phone VARCHAR(20))";
+    let violations = analyze_with_schema("SELECT id FROM users WHERE id = 42 LIMIT 10", schema);
+    assert!(!violations.contains(&"PERF015".to_string()));
+}
+
+#[test]
 fn test_schema_missing_index() {
     let schema = "CREATE TABLE users (id INT PRIMARY KEY, email VARCHAR(255))";
     let violations = analyze_with_schema(


### PR DESCRIPTION
Closes #13

New schema-aware performance rule PERF015 (Warning): flags WHERE comparisons of a text column (CHAR/VARCHAR/TEXT) with a bare numeric literal — the engine casts the column side on every row, disabling its index.

- Registered with the schema-aware rule set (requires --schema)
- README, Cargo.toml description, docs updated to 33 rules; version bumped to 0.14.0
- 3 new tests: flagged bare number, quoted literal negative, numeric column negative

Local checks: fmt, clippy -D warnings, 475 tests, cargo qual (0 issues), mdbook build — all green.