### PR TITLE
#14 feat: add PERF016 rule detecting repeated scans of the same table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "sql_query_analyzer"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sql_query_analyzer"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
-description = "Static analysis tool for SQL queries with 33 built-in rules for performance, security, and style"
+description = "Static analysis tool for SQL queries with 34 built-in rules for performance, security, and style"
 license = "MIT"
 repository = "https://github.com/RAprogramm/sql-query-analyzer"
 homepage = "https://github.com/RAprogramm/sql-query-analyzer"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A comprehensive SQL analysis tool that combines fast, deterministic static analy
 
 ## Highlights
 
-- **33 Built-in Rules** — Performance, style, and security checks run instantly without API calls
+- **34 Built-in Rules** — Performance, style, and security checks run instantly without API calls
 - **Schema-Aware Analysis** — Validates queries against your database schema, suggests missing indexes
 - **Multi-Dialect Support** — Generic, MySQL, PostgreSQL, SQLite, and ClickHouse with preprocessor for dialect-specific syntax
 - **Multiple Output Formats** — Text, JSON, YAML, and SARIF for CI/CD integration
@@ -102,6 +102,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql --provider openai
 | `PERF013` | ORDER BY RAND() | Warning | Full scan and sort regardless of `LIMIT` |
 | `PERF014` | Unnecessary DISTINCT | Info | `DISTINCT` with `JOIN` often hides join fan-out; `DISTINCT *` escalates to Warning |
 | `PERF015` | Implicit type conversion | Warning | Text column compared with numeric literal disables its index (needs schema) |
+| `PERF016` | Multiple scans of same table | Info | Self-joins and repeated subqueries multiply I/O |
 | `PERF018` | HAVING without aggregate | Warning | Non-aggregate conditions belong in `WHERE` |
 | `PERF019` | Large IN clause | Warning | 50+ values degrade planning; severity scales with size |
 | `PERF020` | Deeply nested subqueries | Warning | 3+ SELECT levels; severity scales with depth |
@@ -332,7 +333,7 @@ For fast CI checks without external API calls:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-This runs all 33 built-in rules instantly without requiring any API keys.
+This runs all 34 built-in rules instantly without requiring any API keys.
 
 #### Advanced Usage
 
@@ -452,7 +453,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql
                       ▼
          ┌────────────────────────┐
          │    Static Analysis     │
-         │  (33 rules, parallel)  │
+         │  (34 rules, parallel)  │
          └────────────┬───────────┘
                       │
                       ▼

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -16,7 +16,7 @@ reach production.
 
 ## Highlights
 
-- **33 built-in rules** across performance, style, security, and schema-aware
+- **34 built-in rules** across performance, style, security, and schema-aware
   categories
 - **Schema-aware analysis** — detects missing indexes and unknown columns by
   parsing your `CREATE TABLE` statements

--- a/docs/src/rules/index.md
+++ b/docs/src/rules/index.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Rules Overview
 
-33 built-in rules across four categories. Every rule has a stable ID, a default
+34 built-in rules across four categories. Every rule has a stable ID, a default
 severity, and a suggestion attached to each violation. Rules can be disabled or
 re-weighted via [configuration](../configuration.md).
 

--- a/docs/src/rules/performance.md
+++ b/docs/src/rules/performance.md
@@ -182,6 +182,21 @@ SELECT id FROM users WHERE phone = 5551234;
 SELECT id FROM users WHERE phone = '5551234';
 ```
 
+## PERF016 — Multiple scans of same table (Info)
+
+Repeated `FROM`/`JOIN` references to one table multiply I/O. A CTE, window
+function, or conditional aggregation usually reads the table once.
+
+```sql
+-- Flagged
+SELECT * FROM orders o1 WHERE amount > (SELECT AVG(amount) FROM orders);
+
+-- Better: one scan with a window function
+SELECT * FROM (
+    SELECT o.*, AVG(amount) OVER () AS avg_amount FROM orders o
+) t WHERE amount > avg_amount;
+```
+
 ## PERF018 — HAVING without aggregate (Warning)
 
 `HAVING` filters after grouping; a condition on plain columns forces the

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -205,6 +205,7 @@ impl RuleRunner {
             Box::new(performance::HavingWithoutAggregate),
             Box::new(performance::UnnecessaryDistinct),
             Box::new(performance::DeeplyNestedSubqueries),
+            Box::new(performance::RepeatedTableScan),
             Box::new(style::SelectStar),
             Box::new(style::MissingTableAlias),
             Box::new(style::OrdinalInOrderOrGroupBy),

--- a/src/rules/performance.rs
+++ b/src/rules/performance.rs
@@ -738,6 +738,70 @@ impl Rule for DeeplyNestedSubqueries {
     }
 }
 
+/// Same table scanned more than once in a single statement
+///
+/// Repeated FROM/JOIN references to one table (self-joins, repeated
+/// subqueries over the same data) multiply I/O; a CTE, window function, or
+/// conditional aggregation usually reads the table once instead.
+pub struct RepeatedTableScan;
+
+/// Counts FROM/JOIN references to `table` at word boundaries.
+fn table_scan_count(upper: &str, table: &str) -> usize {
+    ["FROM ", "JOIN "]
+        .iter()
+        .map(|kw| {
+            let needle = format!("{kw}{table}");
+            upper
+                .match_indices(&needle)
+                .filter(|(pos, _)| {
+                    let end = pos + needle.len();
+                    upper[end..]
+                        .chars()
+                        .next()
+                        .is_none_or(|c| !c.is_ascii_alphanumeric() && c != '_')
+                })
+                .count()
+        })
+        .sum()
+}
+
+impl Rule for RepeatedTableScan {
+    fn info(&self) -> RuleInfo {
+        RuleInfo {
+            id:       "PERF016",
+            name:     "Multiple scans of same table",
+            severity: Severity::Info,
+            category: RuleCategory::Performance
+        }
+    }
+
+    fn check(&self, query: &Query, query_index: usize) -> Vec<Violation> {
+        if query.query_type != QueryType::Select {
+            return vec![];
+        }
+        let upper = query.raw.to_uppercase();
+        for table in &query.tables {
+            let scans = table_scan_count(&upper, &table.to_uppercase());
+            if scans >= 2 {
+                let info = self.info();
+                return vec![Violation {
+                    rule_id: info.id,
+                    rule_name: info.name,
+                    message: format!("Table '{}' is scanned {} times", table, scans),
+                    severity: info.severity,
+                    category: info.category,
+                    suggestion: Some(
+                        "Read the table once via a CTE, window function, or conditional aggregation"
+                            .to_string()
+                    ),
+                    query_index
+                }];
+            }
+        }
+        vec![]
+    }
+}
+
 /// DISTINCT with ORDER BY can be inefficient
 pub struct DistinctWithOrderBy;
 

--- a/tests/rules_tests.rs
+++ b/tests/rules_tests.rs
@@ -182,6 +182,28 @@ fn test_distinct_single_table_ok() {
 }
 
 #[test]
+fn test_repeated_table_scan_flagged() {
+    let violations = analyze_query(
+        "SELECT id FROM orders WHERE amount > (SELECT AVG(amount) FROM orders) LIMIT 10"
+    );
+    assert!(violations.contains(&"PERF016".to_string()));
+}
+
+#[test]
+fn test_self_join_flagged() {
+    let violations = analyze_query(
+        "SELECT e.name FROM employees e JOIN employees m ON e.manager_id = m.id WHERE e.id > 0 LIMIT 10"
+    );
+    assert!(violations.contains(&"PERF016".to_string()));
+}
+
+#[test]
+fn test_single_scan_not_flagged() {
+    let violations = analyze_query("SELECT id FROM orders WHERE amount > 100 LIMIT 10");
+    assert!(!violations.contains(&"PERF016".to_string()));
+}
+
+#[test]
 fn test_having_without_aggregate_flagged() {
     let violations = analyze_query(
         "SELECT status, COUNT(*) FROM orders WHERE id > 0 GROUP BY status HAVING status = 'active' LIMIT 10"


### PR DESCRIPTION
Closes #14

New performance rule PERF016 (Info): flags statements that scan one table multiple times (self-joins, repeated subqueries over the same data) by counting word-bounded FROM/JOIN references. A CTE, window function, or conditional aggregation usually reads the table once.

- README, Cargo.toml description, docs updated to 34 rules; version bumped to 0.15.0
- 3 new tests: subquery re-scan, self-join, single-scan negative

Local checks: fmt, clippy -D warnings, tests, cargo qual (0 issues), mdbook build — all green.