### PR TITLE
#15 feat: add PERF017 rule detecting correlated subqueries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "sql_query_analyzer"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sql_query_analyzer"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
-description = "Static analysis tool for SQL queries with 34 built-in rules for performance, security, and style"
+description = "Static analysis tool for SQL queries with 35 built-in rules for performance, security, and style"
 license = "MIT"
 repository = "https://github.com/RAprogramm/sql-query-analyzer"
 homepage = "https://github.com/RAprogramm/sql-query-analyzer"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A comprehensive SQL analysis tool that combines fast, deterministic static analy
 
 ## Highlights
 
-- **34 Built-in Rules** — Performance, style, and security checks run instantly without API calls
+- **35 Built-in Rules** — Performance, style, and security checks run instantly without API calls
 - **Schema-Aware Analysis** — Validates queries against your database schema, suggests missing indexes
 - **Multi-Dialect Support** — Generic, MySQL, PostgreSQL, SQLite, and ClickHouse with preprocessor for dialect-specific syntax
 - **Multiple Output Formats** — Text, JSON, YAML, and SARIF for CI/CD integration
@@ -103,6 +103,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql --provider openai
 | `PERF014` | Unnecessary DISTINCT | Info | `DISTINCT` with `JOIN` often hides join fan-out; `DISTINCT *` escalates to Warning |
 | `PERF015` | Implicit type conversion | Warning | Text column compared with numeric literal disables its index (needs schema) |
 | `PERF016` | Multiple scans of same table | Info | Self-joins and repeated subqueries multiply I/O |
+| `PERF017` | Correlated subquery | Warning | Subquery referencing the outer query re-executes per row |
 | `PERF018` | HAVING without aggregate | Warning | Non-aggregate conditions belong in `WHERE` |
 | `PERF019` | Large IN clause | Warning | 50+ values degrade planning; severity scales with size |
 | `PERF020` | Deeply nested subqueries | Warning | 3+ SELECT levels; severity scales with depth |
@@ -333,7 +334,7 @@ For fast CI checks without external API calls:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-This runs all 34 built-in rules instantly without requiring any API keys.
+This runs all 35 built-in rules instantly without requiring any API keys.
 
 #### Advanced Usage
 
@@ -453,7 +454,7 @@ sql-query-analyzer analyze -s schema.sql -q queries.sql
                       ▼
          ┌────────────────────────┐
          │    Static Analysis     │
-         │  (34 rules, parallel)  │
+         │  (35 rules, parallel)  │
          └────────────┬───────────┘
                       │
                       ▼

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -16,7 +16,7 @@ reach production.
 
 ## Highlights
 
-- **34 built-in rules** across performance, style, security, and schema-aware
+- **35 built-in rules** across performance, style, security, and schema-aware
   categories
 - **Schema-aware analysis** — detects missing indexes and unknown columns by
   parsing your `CREATE TABLE` statements

--- a/docs/src/rules/index.md
+++ b/docs/src/rules/index.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 
 # Rules Overview
 
-34 built-in rules across four categories. Every rule has a stable ID, a default
+35 built-in rules across four categories. Every rule has a stable ID, a default
 severity, and a suggestion attached to each violation. Rules can be disabled or
 re-weighted via [configuration](../configuration.md).
 

--- a/docs/src/rules/performance.md
+++ b/docs/src/rules/performance.md
@@ -197,6 +197,23 @@ SELECT * FROM (
 ) t WHERE amount > avg_amount;
 ```
 
+## PERF017 — Correlated subquery (Warning)
+
+A subquery that references a table or alias of the outer query cannot be
+evaluated once; the engine re-runs it for every candidate row.
+
+```sql
+-- Flagged: the subquery references outer alias u
+SELECT * FROM users u
+WHERE EXISTS (SELECT 1 FROM orders o WHERE o.user_id = u.id);
+
+-- Not flagged: independent subquery, evaluated once
+SELECT * FROM users WHERE id IN (SELECT user_id FROM orders);
+
+-- Better: single pass
+SELECT DISTINCT u.* FROM users u JOIN orders o ON o.user_id = u.id;
+```
+
 ## PERF018 — HAVING without aggregate (Warning)
 
 `HAVING` filters after grouping; a condition on plain columns forces the

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -206,6 +206,7 @@ impl RuleRunner {
             Box::new(performance::UnnecessaryDistinct),
             Box::new(performance::DeeplyNestedSubqueries),
             Box::new(performance::RepeatedTableScan),
+            Box::new(performance::CorrelatedSubquery),
             Box::new(style::SelectStar),
             Box::new(style::MissingTableAlias),
             Box::new(style::OrdinalInOrderOrGroupBy),

--- a/src/rules/performance.rs
+++ b/src/rules/performance.rs
@@ -802,6 +802,154 @@ impl Rule for RepeatedTableScan {
     }
 }
 
+/// Correlated subqueries re-execute per outer row
+///
+/// A subquery that references a table or alias of the outer query cannot be
+/// evaluated once; the engine re-runs it for every candidate row. JOINs or
+/// window functions usually express the same logic with a single pass.
+pub struct CorrelatedSubquery;
+
+/// Extracts each balanced `(SELECT …)` body from the statement.
+fn subquery_bodies(upper: &str) -> Vec<&str> {
+    let mut bodies = Vec::new();
+    let mut search_from = 0;
+    while let Some(pos) = upper[search_from..].find("(SELECT") {
+        let start = search_from + pos + 1;
+        let mut depth = 1usize;
+        let mut end = start;
+        for (i, b) in upper[start..].bytes().enumerate() {
+            match b {
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = start + i;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        if end > start {
+            bodies.push(&upper[start..end]);
+        }
+        search_from = start;
+    }
+    bodies
+}
+
+/// Collects table names and aliases declared by FROM/JOIN inside a body.
+fn body_sources(body: &str) -> Vec<&str> {
+    let mut sources = Vec::new();
+    let tokens: Vec<&str> = body
+        .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .filter(|t| !t.is_empty())
+        .collect();
+    let alias_stoppers = [
+        "ON", "WHERE", "JOIN", "LEFT", "RIGHT", "INNER", "FULL", "CROSS", "GROUP", "ORDER",
+        "LIMIT", "HAVING", "UNION", "SELECT", "AS"
+    ];
+    let mut i = 0;
+    while i < tokens.len() {
+        if (tokens[i] == "FROM" || tokens[i] == "JOIN")
+            && let Some(table) = tokens.get(i + 1)
+        {
+            sources.push(*table);
+            if let Some(alias) = tokens.get(i + 2)
+                && !alias_stoppers.contains(alias)
+                && !alias.chars().next().is_some_and(|c| c.is_ascii_digit())
+            {
+                sources.push(*alias);
+            }
+        }
+        i += 1;
+    }
+    sources
+}
+
+/// Replaces single-quoted string literal contents with spaces so dots in
+/// literals ('a@example.com') never look like qualified column references.
+fn mask_string_literals(body: &str) -> String {
+    let mut masked = String::with_capacity(body.len());
+    let mut in_quote = false;
+    for c in body.chars() {
+        if c == '\'' {
+            in_quote = !in_quote;
+            masked.push(' ');
+        } else {
+            masked.push(if in_quote { ' ' } else { c });
+        }
+    }
+    masked
+}
+
+/// Returns true when the body qualifies a column with a prefix that is not
+/// declared inside the body itself — i.e. it references the outer query.
+fn references_outer_source(raw_body: &str) -> bool {
+    let body = &mask_string_literals(raw_body);
+    let sources = body_sources(body);
+    let bytes = body.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'.' && i > 0 {
+            let mut start = i;
+            while start > 0 {
+                let c = bytes[start - 1];
+                if c.is_ascii_alphanumeric() || c == b'_' {
+                    start -= 1;
+                } else {
+                    break;
+                }
+            }
+            let prefix = &body[start..i];
+            if !prefix.is_empty()
+                && !prefix.chars().next().is_some_and(|c| c.is_ascii_digit())
+                && !sources.contains(&prefix)
+            {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+impl Rule for CorrelatedSubquery {
+    fn info(&self) -> RuleInfo {
+        RuleInfo {
+            id:       "PERF017",
+            name:     "Correlated subquery",
+            severity: Severity::Warning,
+            category: RuleCategory::Performance
+        }
+    }
+
+    fn check(&self, query: &Query, query_index: usize) -> Vec<Violation> {
+        if query.query_type != QueryType::Select || !query.has_subquery {
+            return vec![];
+        }
+        let upper = query.raw.to_uppercase();
+        if !subquery_bodies(&upper)
+            .iter()
+            .any(|body| references_outer_source(body))
+        {
+            return vec![];
+        }
+        let info = self.info();
+        vec![Violation {
+            rule_id: info.id,
+            rule_name: info.name,
+            message: "Correlated subquery re-executes for every outer row".to_string(),
+            severity: info.severity,
+            category: info.category,
+            suggestion: Some(
+                "Rewrite as a JOIN or window function so the inner data is read once".to_string()
+            ),
+            query_index
+        }]
+    }
+}
+
 /// DISTINCT with ORDER BY can be inefficient
 pub struct DistinctWithOrderBy;
 

--- a/tests/rules_tests.rs
+++ b/tests/rules_tests.rs
@@ -182,6 +182,37 @@ fn test_distinct_single_table_ok() {
 }
 
 #[test]
+fn test_correlated_exists_flagged() {
+    let violations = analyze_query(
+        "SELECT id FROM users u WHERE EXISTS (SELECT 1 FROM orders o WHERE o.user_id = u.id) LIMIT 10"
+    );
+    assert!(violations.contains(&"PERF017".to_string()));
+}
+
+#[test]
+fn test_correlated_scalar_projection_flagged() {
+    let violations = analyze_query(
+        "SELECT name, (SELECT MAX(total) FROM orders WHERE user_id = users.id) FROM users WHERE id > 0 LIMIT 10"
+    );
+    assert!(violations.contains(&"PERF017".to_string()));
+}
+
+#[test]
+fn test_uncorrelated_in_subquery_ok() {
+    let violations =
+        analyze_query("SELECT id FROM users WHERE id IN (SELECT user_id FROM orders) LIMIT 10");
+    assert!(!violations.contains(&"PERF017".to_string()));
+}
+
+#[test]
+fn test_literal_dot_not_correlated() {
+    let violations = analyze_query(
+        "SELECT id FROM users WHERE id IN (SELECT user_id FROM orders WHERE note = 'a@b.com') LIMIT 10"
+    );
+    assert!(!violations.contains(&"PERF017".to_string()));
+}
+
+#[test]
 fn test_repeated_table_scan_flagged() {
     let violations = analyze_query(
         "SELECT id FROM orders WHERE amount > (SELECT AVG(amount) FROM orders) LIMIT 10"


### PR DESCRIPTION
Closes #15

New performance rule PERF017 (Warning): flags subqueries that qualify columns with a source not declared inside the subquery body — i.e. references to the outer query, which force per-row re-execution. Uncorrelated IN/scalar subqueries are not flagged; string literals are masked so dots in values (a@b.com) never look like qualified references.

- README, Cargo.toml description, docs updated to 35 rules; version bumped to 0.16.0
- 4 new tests: EXISTS and scalar-projection correlation, uncorrelated negative, literal-dot negative

Local checks: fmt, clippy -D warnings, tests, cargo qual (0 issues), mdbook build — all green.